### PR TITLE
Miner and node function changes to preserve one broadcast

### DIFF
--- a/bns/bitcoin-miner.cc_original
+++ b/bns/bitcoin-miner.cc_original
@@ -32,27 +32,7 @@ BitcoinMiner::StartMining()
 
     ns3::Time nextBlockTime = GetNextBlockTime();
     NS_LOG_INFO("Starting mining on new block. Prev ID:" << prevID << ", Prev Height: " << m_nodeCtx->GetBlockchain()->GetTopBlockHeight() << ", will be found in " << nextBlockTime.GetSeconds() << " seconds.");
-
-    // ###### Mincast ######
-    //NS_LOG_INFO("Test nextBlockTime: " << nextBlockTime.GetSeconds());
-    uint64_t timerBroadcast = 10000;
-    NS_LOG_INFO("");
-    NS_LOG_INFO("");
-    NS_LOG_INFO("");
-    NS_LOG_INFO("Start to broadcast " << timerBroadcast / 1000 << " seconds after the simulation starts");
-    NS_LOG_INFO("Start to broadcast " << timerBroadcast / 1000 << " seconds after the simulation starts");
-    NS_LOG_INFO("Start to broadcast " << timerBroadcast / 1000 << " seconds after the simulation starts");
-    NS_LOG_INFO("Start to broadcast " << timerBroadcast / 1000 << " seconds after the simulation starts");
-    NS_LOG_INFO("Start to broadcast " << timerBroadcast / 1000 << " seconds after the simulation starts");
-    NS_LOG_INFO("Start to broadcast " << timerBroadcast / 1000 << " seconds after the simulation starts");
-    NS_LOG_INFO("Start to broadcast " << timerBroadcast / 1000 << " seconds after the simulation starts");
-    NS_LOG_INFO("");
-    NS_LOG_INFO("");
-    NS_LOG_INFO("");
-    //m_curMiningEvent = ns3::Simulator::Schedule(nextBlockTime, &BitcoinMiner::MineBlock, this, prevID);
-    // ###### Mincast ######
-
-    m_curMiningEvent = ns3::Simulator::Schedule(ns3::Seconds(timerBroadcast), &BitcoinMiner::MineBlock, this, prevID);
+    m_curMiningEvent = ns3::Simulator::Schedule(nextBlockTime, &BitcoinMiner::MineBlock, this, prevID);
 }
 
 void 
@@ -67,8 +47,6 @@ void
 BitcoinMiner::MineBlock(uint64_t prevID)
 {
     NS_LOG_FUNCTION(this);
-    NS_LOG_INFO("MineBlock Now");
-
     if(!m_mining) return; // do nothing if we should not be mining
 	ns3::Ptr<ns3::UniformRandomVariable> rand = ns3::CreateObject<ns3::UniformRandomVariable> ();	
     double min = std::numeric_limits<uint64_t>::min();

--- a/bns/bitcoin-node.cc
+++ b/bns/bitcoin-node.cc
@@ -4,7 +4,7 @@ NS_LOG_COMPONENT_DEFINE ("BNSBitcoinNode");
 
 namespace bns {
 
-BitcoinNode::BitcoinNode (ns3::Ipv4Address address, bool isMiner, double hashRate) : m_socket(0), m_address (address), m_isRunning(false), m_isMiner(isMiner), m_isSelfish(false), m_isByzantine(false), m_miner(nullptr), m_hashRate(hashRate), m_ttfb(0), m_ttlb(0), m_miningTime(0), m_nMinedBlocks(0), m_totalMinedBlocksSize(0), m_receivedFirstPartBlock(false), m_receivedFirstFullBlock(false)
+BitcoinNode::BitcoinNode (ns3::Ipv4Address address, bool isMiner, double hashRate) : m_socket(0), m_address (address), m_isRunning(false), m_isMiner(isMiner), m_isSelfish(false), m_isByzantine(false), m_miner(nullptr), m_hashRate(hashRate), m_receivedFirstPartBlock(false), m_receivedFirstFullBlock(false), m_ttfb(0), m_ttlb(0), m_miningTime(0), m_nMinedBlocks(0), m_totalMinedBlocksSize(0)
 { 
     NS_LOG_FUNCTION(this);
     m_blockchain = new Blockchain(this);

--- a/bns/bitcoin-node.cc_original
+++ b/bns/bitcoin-node.cc_original
@@ -34,12 +34,7 @@ BitcoinNode::NotifyNewValidBlock(Block& newBlock)
     if (m_isMiner) {
         // Restart mining immediately, validation delay is added before
         // NotifyNewValidBlock is called
-        //m_miner->StartMining();
-
-        // ###### Mincast ######
-        // Only 1 broadcast, no more restart
-        m_miner->StopMining();
-        // ###### Mincast ######
+        m_miner->StartMining();
     }
 
     if (!m_isSelfish && !m_isByzantine) {

--- a/bns/bitcoin-topology-helper.cc
+++ b/bns/bitcoin-topology-helper.cc
@@ -376,5 +376,6 @@ BitcoinTopologyHelper::RegionToString(Region reg)
         case Region::CN:
             return "CN";
     }
+    return "";
 }
 }

--- a/bns/bns.cc
+++ b/bns/bns.cc
@@ -42,7 +42,8 @@ struct bnsParams {
     uint32_t seed = 23;
     uint16_t nHours = 12;
     uint32_t nPeers = 100;
-    uint32_t nMiners = bns::btcNumPools;
+    //uint32_t nMiners = bns::btcNumPools;
+    uint32_t nMiners = 1;
     uint32_t nBootstrap = nPeers;
     double blockSizeFactor = 1.0;
     double blockIntervalFactor = 1.0;
@@ -103,7 +104,7 @@ main (int argc, char *argv[])
     cmd.AddValue("blockSizeFactor", "Set how big blocks are (as a factor of 1 MB)", params.blockSizeFactor);
     cmd.AddValue("blockIntervalFactor", "Set how fast blocks are produced are (as a factor of 10 minutes)", params.blockIntervalFactor);
     cmd.AddValue("byzantineFactor", "Set what part of nodes are byzantine", params.byzantineFactor);
-    cmd.AddValue("net", "Set the network stack (mincast or mincast or kadcast)", params.netStack);
+    cmd.AddValue("net", "Set the network stack (mincast or kadcast)", params.netStack);
     cmd.AddValue("topo", "Set the network topology (star or geo)", params.topo);
 
     cmd.AddValue("unsolicited", "Mincast: Enable unsolicited block transmission.", params.unsolicited);

--- a/bns/logs/kadcast.log
+++ b/bns/logs/kadcast.log
@@ -1,0 +1,907 @@
+Waf: Entering directory `/root/ns3/ns3-allinone-build-version/ns-3-dev/build'
+Waf: Leaving directory `/root/ns3/ns3-allinone-build-version/ns-3-dev/build'
+Build commands will be stored in build/compile_commands.json
+'build' finished successfully (2.113s)
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 1(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 120.173
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 8.88921
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 18.6517
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 2(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 0.568956
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 5.83134
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 6.23416
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 3(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 13.8093
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 26.4436
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 11.9251
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 4(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 36.0853
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 0.246853
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 5.57218
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 5(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 26.9462
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 14.123
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 8.82795
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 6(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 47.3436
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 7.80331
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 2.33644
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 7(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 31.4452
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 10.7516
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 14.2873
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 8(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 21.0406
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 0.0447379
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 4.77584
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 9(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 13.9878
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 6.89135
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 1.11436
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 10(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 25.0756
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 20.331
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 7.36613
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 11(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 43.5417
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 22.008
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 12.5514
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 12(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 12.0406
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 21.7329
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 16.4545
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 13(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 81.8338
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 24.3911
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 13.6484
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 14(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 55.3613
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 0.573648
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 16.4218
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 15(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 28.9562
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 17.6066
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 20.923
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 16(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 34.3309
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 16.415
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 16.9496
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 17(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 58.5002
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 27.2036
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 8.87262
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 18(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 54.5194
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 27.6424
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 14.2451
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 19(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 63.1409
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 1.53098
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 7.02345
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 20(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 59.4948
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 13.2326
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 23.1538
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 21(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 17.3457
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 32.5167
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 21.5968
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 23(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 24.2395
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 20.2939
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 1.40567
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 24(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 80.1656
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 71.5714
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 10.3862
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 25(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 63.3821
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 24.0193
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 4.28825
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 26(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 81.886
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 53.2797
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 9.06935
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 27(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 62.7373
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 49.2004
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 5.20838
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 28(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 49.6386
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 34.845
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 14.2946
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 29(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 55.0728
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 28.1114
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 4.94118
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 30(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 103.894
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 21.6628
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 5.68566
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 31(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 62.4758
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 50.5346
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 10.7704
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 32(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 104.946
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 8.00848
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 18.7409
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 33(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 46.563
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 36.2011
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 50.9865
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 34(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 66.761
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 0.433148
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 5.25549
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 35(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 60.6823
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 27.4568
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 11.4635
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 36(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 50.0394
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 88.2833
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 8.0401
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 37(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 37.2014
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 56.876
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 9.87873
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 38(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 87.0679
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 0.693451
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 6.40138
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 39(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 66.0045
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 8.20296
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 11.9416
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 40(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 35.5545
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 37.077
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 11.9624
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 41(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 77.0539
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 42.5116
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 9.20812
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 42(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 108.086
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 28.811
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 9.99615
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 43(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 52.1376
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 44.0088
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 66.9788
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 44(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 84.3963
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 43.8716
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 12.2545
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 45(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 85.518
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 25.3317
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 5.37523
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 46(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 79.7461
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 29.4248
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 13.7694
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 47(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 81.5398
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 38.3988
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 12.2935
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 48(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 19.0322
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 43.9584
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 5.36659
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 49(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 109.514
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 73.6877
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 20.5007
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 50(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 59.0666
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 60.598
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 0.520477
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 51(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 52.3795
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 20.3082
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 12.1624
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 52(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 99.778
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 97.8526
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 13.2369
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 53(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 8.26582
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 51.7863
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 16.0015
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 54(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 122.329
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 42.1379
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 2.76628
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 55(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 25.0075
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 51.5596
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 10.172
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 56(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 87.8781
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 42.7979
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 6.17589
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 57(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 87.1286
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 36.806
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 13.6092
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 58(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 13.1089
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 14.6666
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 4.72991
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 59(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 9.55396
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 48.0387
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 2.80014
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 60(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 20.93
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 44.0098
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 145.905
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 61(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 57.1988
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 11.7346
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 10.7725
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 62(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 17.6429
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 43.7953
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 4.07978
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 63(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 118.061
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 5.76752
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 11.4383
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 64(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 6.69103
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 26.4434
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 16.2261
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 65(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 7.27829
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 60.1724
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 6.14795
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 66(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 95.7612
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 49.5386
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 6.63352
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 67(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 98.2182
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 48.5236
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 4.55957
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 68(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 58.6956
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 37.2186
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 5.13018
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 69(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 41.3491
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 28.258
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 1.6225
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 70(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 35.827
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 50.2461
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 25.428
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 71(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 76.4396
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 44.6068
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 9.96941
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 72(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 80.9808
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 11.9823
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 7.66905
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 73(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 37.661
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 45.9292
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 23.8808
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 74(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 60.4349
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 8.09944
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 1.28072
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 75(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 63.0751
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 36.4004
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 6.64156
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 76(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 106.759
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 56.2896
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 11.3263
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 77(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 50.9426
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 14.2738
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 9.5388
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 78(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 12.5058
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 35.932
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 3.58745
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 79(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 46.6411
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 47.3779
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 2.79725
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 81(AS):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 25.2564
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 23.9413
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 1.7325
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 82(AS):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 31.1365
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 12.9002
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 6.80114
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 83(AS):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 49.4199
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 9.95112
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 1.20631
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 84(AS):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 57.8697
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 25.2836
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 34.5997
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 85(AS):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 89.797
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 68.8117
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 87.0584
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 86(AS):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 93.0964
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 34.3513
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 1.17414
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 87(AS):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 8.20801
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 45.874
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 3.30064
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 88(AS):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 9.77014
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 111.056
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 0.93658
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 89(AS):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 23.7282
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 52.6017
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 8.76698
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 90(AS):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 33.8779
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 27.9081
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 84.4558
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 92(OC):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 27.8908
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 22.9889
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 9.49478
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 93(OC):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 4.02685
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 1.36615
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 1.153
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 95(AF):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 5.88962
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 7.59419
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 97.3127
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 97(SA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 13.7111
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 7.15242
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 58.0925
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 99(CN):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 93.7893
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 77.4536
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 7.42191
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 100(CN):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 168.322
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 68.0679
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 1.17163
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 101(CN):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 126.021
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 57.6436
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 4.38055
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 102(CN):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 205.426
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 114.544
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 3.83817
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 103(CN):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 133.11
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 105.928
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 80.9099
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 104(CN):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 66.6997
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 166.014
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 0.333463
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 105(CN):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 136.144
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 78.2486
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 0.570304
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 106(CN):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 237.689
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 40.0844
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 3.76867
++0.000000000s -1 BNSBitcoinTopologyHelper:BitcoinTopologyHelper(): [INFO ] All Continents successfully connected
++0.000000000s -1 BNSBitcoinTopologyHelper:BitcoinTopologyHelper(): [INFO ] Amount of Nodes in each Continent:
++0.000000000s -1 BNSBitcoinTopologyHelper:BitcoinTopologyHelper(): [INFO ] NA: 21
++0.000000000s -1 BNSBitcoinTopologyHelper:BitcoinTopologyHelper(): [INFO ] EU: 57
++0.000000000s -1 BNSBitcoinTopologyHelper:BitcoinTopologyHelper(): [INFO ] AS: 10
++0.000000000s -1 BNSBitcoinTopologyHelper:BitcoinTopologyHelper(): [INFO ] OC: 2
++0.000000000s -1 BNSBitcoinTopologyHelper:BitcoinTopologyHelper(): [INFO ] AF: 1
++0.000000000s -1 BNSBitcoinTopologyHelper:BitcoinTopologyHelper(): [INFO ] SA: 1
++0.000000000s -1 BNSBitcoinTopologyHelper:BitcoinTopologyHelper(): [INFO ] CN: 8
++0.000000000s -1 BNSBitcoinTopologyHelper:BitcoinTopologyHelper(): [INFO ] TOTAL: 100
++0.000000000s -1 BNS:main(): [INFO ] Marked 0 nodes as byzantine.
++0.000000000s -1 BNS:main(): [INFO ] Running Simulator!
++2.000000000s 1 BNSKadcastNode:StartApplication(): [INFO ] Starting node 1: 10.1.0.1 / 3203351596746076160
++2.000000000s 2 BNSKadcastNode:StartApplication(): [INFO ] Starting node 2: 10.1.0.2 / 11107912316276983808
++2.000000000s 3 BNSKadcastNode:StartApplication(): [INFO ] Starting node 3: 10.1.0.3 / 8172678133302334464
++2.000000000s 4 BNSKadcastNode:StartApplication(): [INFO ] Starting node 4: 10.1.0.4 / 17763284559063138304
++2.000000000s 5 BNSKadcastNode:StartApplication(): [INFO ] Starting node 5: 10.1.0.5 / 8442153207776613376
++2.000000000s 6 BNSKadcastNode:StartApplication(): [INFO ] Starting node 6: 10.1.0.6 / 15635324140198340608
++2.000000000s 7 BNSKadcastNode:StartApplication(): [INFO ] Starting node 7: 10.1.0.7 / 10703215876476239872
++2.000000000s 8 BNSKadcastNode:StartApplication(): [INFO ] Starting node 8: 10.1.0.8 / 13773729011701647360
++2.000000000s 9 BNSKadcastNode:StartApplication(): [INFO ] Starting node 9: 10.1.0.9 / 6720192029795482624
++2.000000000s 10 BNSKadcastNode:StartApplication(): [INFO ] Starting node 10: 10.1.0.10 / 17555801787116115968
++2.000000000s 11 BNSKadcastNode:StartApplication(): [INFO ] Starting node 11: 10.1.0.11 / 16320239438375204864
++2.000000000s 12 BNSKadcastNode:StartApplication(): [INFO ] Starting node 12: 10.1.0.12 / 162843976382015648
++2.000000000s 13 BNSKadcastNode:StartApplication(): [INFO ] Starting node 13: 10.1.0.13 / 10745092174712477696
++2.000000000s 14 BNSKadcastNode:StartApplication(): [INFO ] Starting node 14: 10.1.0.14 / 2612149062122424832
++2.000000000s 15 BNSKadcastNode:StartApplication(): [INFO ] Starting node 15: 10.1.0.15 / 14368473112104585216
++2.000000000s 16 BNSKadcastNode:StartApplication(): [INFO ] Starting node 16: 10.1.0.16 / 15774062761788018688
++2.000000000s 17 BNSKadcastNode:StartApplication(): [INFO ] Starting node 17: 10.1.0.17 / 2292183268794167552
++2.000000000s 18 BNSKadcastNode:StartApplication(): [INFO ] Starting node 18: 10.1.0.18 / 13085723192347865088
++2.000000000s 19 BNSKadcastNode:StartApplication(): [INFO ] Starting node 19: 10.1.0.19 / 9090094582410557440
++2.000000000s 20 BNSKadcastNode:StartApplication(): [INFO ] Starting node 20: 10.1.0.20 / 3355615002286370304
++2.000000000s 21 BNSKadcastNode:StartApplication(): [INFO ] Starting node 21: 10.1.0.21 / 1746133620165880320
++2.000000000s 23 BNSKadcastNode:StartApplication(): [INFO ] Starting node 23: 10.3.0.1 / 11398677896855926784
++2.000000000s 24 BNSKadcastNode:StartApplication(): [INFO ] Starting node 24: 10.3.0.2 / 10845029587424593920
++2.000000000s 25 BNSKadcastNode:StartApplication(): [INFO ] Starting node 25: 10.3.0.3 / 6058416371557616640
++2.000000000s 26 BNSKadcastNode:StartApplication(): [INFO ] Starting node 26: 10.3.0.4 / 14710757042642382848
++2.000000000s 27 BNSKadcastNode:StartApplication(): [INFO ] Starting node 27: 10.3.0.5 / 16149068799903248384
++2.000000000s 28 BNSKadcastNode:StartApplication(): [INFO ] Starting node 28: 10.3.0.6 / 15336093479316740096
++2.000000000s 29 BNSKadcastNode:StartApplication(): [INFO ] Starting node 29: 10.3.0.7 / 4703335097339571200
++2.000000000s 30 BNSKadcastNode:StartApplication(): [INFO ] Starting node 30: 10.3.0.8 / 17096289540350287872
++2.000000000s 31 BNSKadcastNode:StartApplication(): [INFO ] Starting node 31: 10.3.0.9 / 2815977770206327808
++2.000000000s 32 BNSKadcastNode:StartApplication(): [INFO ] Starting node 32: 10.3.0.10 / 9265672248383660032
++2.000000000s 33 BNSKadcastNode:StartApplication(): [INFO ] Starting node 33: 10.3.0.11 / 6008451777632944128
++2.000000000s 34 BNSKadcastNode:StartApplication(): [INFO ] Starting node 34: 10.3.0.12 / 13340053932230152192
++2.000000000s 35 BNSKadcastNode:StartApplication(): [INFO ] Starting node 35: 10.3.0.13 / 8308362667924430848
++2.000000000s 36 BNSKadcastNode:StartApplication(): [INFO ] Starting node 36: 10.3.0.14 / 1559528491982265344
++2.000000000s 37 BNSKadcastNode:StartApplication(): [INFO ] Starting node 37: 10.3.0.15 / 11184216820622202880
++2.000000000s 38 BNSKadcastNode:StartApplication(): [INFO ] Starting node 38: 10.3.0.16 / 10927837750607712256
++2.000000000s 39 BNSKadcastNode:StartApplication(): [INFO ] Starting node 39: 10.3.0.17 / 7524392023101681664
++2.000000000s 40 BNSKadcastNode:StartApplication(): [INFO ] Starting node 40: 10.3.0.18 / 16625486421016928256
++2.000000000s 41 BNSKadcastNode:StartApplication(): [INFO ] Starting node 41: 10.3.0.19 / 7344299839475709952
++2.000000000s 42 BNSKadcastNode:StartApplication(): [INFO ] Starting node 42: 10.3.0.20 / 8360239308367436800
++2.000000000s 43 BNSKadcastNode:StartApplication(): [INFO ] Starting node 43: 10.3.0.21 / 3303768551169949696
++2.000000000s 44 BNSKadcastNode:StartApplication(): [INFO ] Starting node 44: 10.3.0.22 / 192102476135327328
++2.000000000s 45 BNSKadcastNode:StartApplication(): [INFO ] Starting node 45: 10.3.0.23 / 17132623238857191424
++2.000000000s 46 BNSKadcastNode:StartApplication(): [INFO ] Starting node 46: 10.3.0.24 / 5998481775076623360
++2.000000000s 47 BNSKadcastNode:StartApplication(): [INFO ] Starting node 47: 10.3.0.25 / 14638955962048970752
++2.000000000s 48 BNSKadcastNode:StartApplication(): [INFO ] Starting node 48: 10.3.0.26 / 8630128993234747392
++2.000000000s 49 BNSKadcastNode:StartApplication(): [INFO ] Starting node 49: 10.3.0.27 / 7413888586602779648
++2.000000000s 50 BNSKadcastNode:StartApplication(): [INFO ] Starting node 50: 10.3.0.28 / 17626884976776138752
++2.000000000s 51 BNSKadcastNode:StartApplication(): [INFO ] Starting node 51: 10.3.0.29 / 2857523549218295296
++2.000000000s 52 BNSKadcastNode:StartApplication(): [INFO ] Starting node 52: 10.3.0.30 / 8649115704540069888
++2.000000000s 53 BNSKadcastNode:StartApplication(): [INFO ] Starting node 53: 10.3.0.31 / 7124265278401331200
++2.000000000s 54 BNSKadcastNode:StartApplication(): [INFO ] Starting node 54: 10.3.0.32 / 5362895170820692992
++2.000000000s 55 BNSKadcastNode:StartApplication(): [INFO ] Starting node 55: 10.3.0.33 / 18040153355671040000
++2.000000000s 56 BNSKadcastNode:StartApplication(): [INFO ] Starting node 56: 10.3.0.34 / 10021588496182777856
++2.000000000s 57 BNSKadcastNode:StartApplication(): [INFO ] Starting node 57: 10.3.0.35 / 11172636737827852288
++2.000000000s 58 BNSKadcastNode:StartApplication(): [INFO ] Starting node 58: 10.3.0.36 / 14798503310353485824
++2.000000000s 59 BNSKadcastNode:StartApplication(): [INFO ] Starting node 59: 10.3.0.37 / 13360782828383993856
++2.000000000s 60 BNSKadcastNode:StartApplication(): [INFO ] Starting node 60: 10.3.0.38 / 17497618991915882496
++2.000000000s 61 BNSKadcastNode:StartApplication(): [INFO ] Starting node 61: 10.3.0.39 / 6626586086379062272
++2.000000000s 62 BNSKadcastNode:StartApplication(): [INFO ] Starting node 62: 10.3.0.40 / 18286738284868628480
++2.000000000s 63 BNSKadcastNode:StartApplication(): [INFO ] Starting node 63: 10.3.0.41 / 13880937765743329280
++2.000000000s 64 BNSKadcastNode:StartApplication(): [INFO ] Starting node 64: 10.3.0.42 / 5832015547655791616
++2.000000000s 65 BNSKadcastNode:StartApplication(): [INFO ] Starting node 65: 10.3.0.43 / 5995459281890000896
++2.000000000s 66 BNSKadcastNode:StartApplication(): [INFO ] Starting node 66: 10.3.0.44 / 4135170188586762240
++2.000000000s 67 BNSKadcastNode:StartApplication(): [INFO ] Starting node 67: 10.3.0.45 / 4190947355308136448
++2.000000000s 68 BNSKadcastNode:StartApplication(): [INFO ] Starting node 68: 10.3.0.46 / 16362987902777577472
++2.000000000s 69 BNSKadcastNode:StartApplication(): [INFO ] Starting node 69: 10.3.0.47 / 17295659689912932352
++2.000000000s 70 BNSKadcastNode:StartApplication(): [INFO ] Starting node 70: 10.3.0.48 / 5126969023823074304
++2.000000000s 71 BNSKadcastNode:StartApplication(): [INFO ] Starting node 71: 10.3.0.49 / 1653714548069515776
++2.000000000s 72 BNSKadcastNode:StartApplication(): [INFO ] Starting node 72: 10.3.0.50 / 4132111467349243392
++2.000000000s 73 BNSKadcastNode:StartApplication(): [INFO ] Starting node 73: 10.3.0.51 / 17017239117250867200
++2.000000000s 74 BNSKadcastNode:StartApplication(): [INFO ] Starting node 74: 10.3.0.52 / 15441845337431388160
++2.000000000s 75 BNSKadcastNode:StartApplication(): [INFO ] Starting node 75: 10.3.0.53 / 11749228222499647488
++2.000000000s 76 BNSKadcastNode:StartApplication(): [INFO ] Starting node 76: 10.3.0.54 / 6786168107956237312
++2.000000000s 77 BNSKadcastNode:StartApplication(): [INFO ] Starting node 77: 10.3.0.55 / 3842820516618157056
++2.000000000s 78 BNSKadcastNode:StartApplication(): [INFO ] Starting node 78: 10.3.0.56 / 6714572455658541056
++2.000000000s 79 BNSKadcastNode:StartApplication(): [INFO ] Starting node 79: 10.3.0.57 / 4278687300827073536
++2.000000000s 81 BNSKadcastNode:StartApplication(): [INFO ] Starting node 81: 10.5.0.1 / 16949707582248798208
++2.000000000s 82 BNSKadcastNode:StartApplication(): [INFO ] Starting node 82: 10.5.0.2 / 16121050957348044800
++2.000000000s 83 BNSKadcastNode:StartApplication(): [INFO ] Starting node 83: 10.5.0.3 / 15718099090397751296
++2.000000000s 84 BNSKadcastNode:StartApplication(): [INFO ] Starting node 84: 10.5.0.4 / 7974597328689424384
++2.000000000s 85 BNSKadcastNode:StartApplication(): [INFO ] Starting node 85: 10.5.0.5 / 323978267934616576
++2.000000000s 86 BNSKadcastNode:StartApplication(): [INFO ] Starting node 86: 10.5.0.6 / 11141109279756625920
++2.000000000s 87 BNSKadcastNode:StartApplication(): [INFO ] Starting node 87: 10.5.0.7 / 13053127253735831552
++2.000000000s 88 BNSKadcastNode:StartApplication(): [INFO ] Starting node 88: 10.5.0.8 / 11159195194642432000
++2.000000000s 89 BNSKadcastNode:StartApplication(): [INFO ] Starting node 89: 10.5.0.9 / 15812014683791339520
++2.000000000s 90 BNSKadcastNode:StartApplication(): [INFO ] Starting node 90: 10.5.0.10 / 2669834461430988288
++2.000000000s 92 BNSKadcastNode:StartApplication(): [INFO ] Starting node 92: 10.7.0.1 / 13776558038077052928
++2.000000000s 93 BNSKadcastNode:StartApplication(): [INFO ] Starting node 93: 10.7.0.2 / 3373422762191715328
++2.000000000s 95 BNSKadcastNode:StartApplication(): [INFO ] Starting node 95: 10.9.0.1 / 6808936649817988096
++2.000000000s 97 BNSKadcastNode:StartApplication(): [INFO ] Starting node 97: 10.11.0.1 / 4759765678942166016
++2.000000000s 99 BNSKadcastNode:StartApplication(): [INFO ] Starting node 99: 10.13.0.1 / 4807282536526569472
++2.000000000s 100 BNSKadcastNode:StartApplication(): [INFO ] Starting node 100: 10.13.0.2 / 4556698116409386496
++2.000000000s 101 BNSKadcastNode:StartApplication(): [INFO ] Starting node 101: 10.13.0.3 / 5781484670855651328
++2.000000000s 102 BNSKadcastNode:StartApplication(): [INFO ] Starting node 102: 10.13.0.4 / 15169670708377112576
++2.000000000s 103 BNSKadcastNode:StartApplication(): [INFO ] Starting node 103: 10.13.0.5 / 7683594665904261120
++2.000000000s 104 BNSKadcastNode:StartApplication(): [INFO ] Starting node 104: 10.13.0.6 / 2786054834685179904
++2.000000000s 105 BNSKadcastNode:StartApplication(): [INFO ] Starting node 105: 10.13.0.7 / 6382865428060217344
++2.000000000s 106 BNSKadcastNode:StartApplication(): [INFO ] Starting node 106: 10.13.0.8 / 18126432157540083712
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] Starting mining on new block. Prev ID:0, Prev Height: 0, will be found in 1601.72 seconds.
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] 
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] 
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] 
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] Start to broadcast 10 seconds after the simulation starts
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] Start to broadcast 10 seconds after the simulation starts
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] Start to broadcast 10 seconds after the simulation starts
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] Start to broadcast 10 seconds after the simulation starts
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] Start to broadcast 10 seconds after the simulation starts
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] Start to broadcast 10 seconds after the simulation starts
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] Start to broadcast 10 seconds after the simulation starts
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] 
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] 
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] 
++10202.000000000s 21 BNSBitcoinMiner:MineBlock(): [INFO ] MineBlock Now
++10202.000000000s 21 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10202.000000000s 21 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Mined new BLOCK 11389160339061379072 size: 1112867
++10202.363350208s 26 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10202.718434489s 30 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10202.785899831s 26 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10202.785899831s 26 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10203.140984112s 30 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10203.140984112s 30 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10203.207488897s 32 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10203.417557863s 24 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10203.583314248s 38 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10203.630038520s 32 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10203.630038520s 32 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10203.685407364s 13 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10203.733536636s 60 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10203.747888713s 88 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10203.774347469s 59 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10203.840107486s 24 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10203.840107486s 24 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10204.005863871s 38 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10204.005863871s 38 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10204.055342730s 23 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10204.107956987s 13 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10204.107956987s 13 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10204.154671454s 41 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10204.156086259s 60 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10204.156086259s 60 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10204.159251209s 34 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10204.162462253s 40 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10204.170438336s 88 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10204.170438336s 88 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10204.196897092s 59 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10204.196897092s 59 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10204.212702712s 86 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10204.344769901s 8 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10204.477892353s 23 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10204.477892353s 23 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10204.569974526s 18 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10204.577221077s 41 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10204.577221077s 41 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10204.581800832s 34 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10204.581800832s 34 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10204.585011876s 40 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10204.585011876s 40 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10204.598104962s 11 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10204.635252335s 86 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10204.635252335s 86 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10204.699996202s 4 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10204.713826233s 92 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10204.767319524s 8 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10204.767319524s 8 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10204.785304689s 28 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10204.800606019s 56 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10204.816578816s 61 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10204.872755541s 76 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10204.992397646s 89 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10204.992524149s 18 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10204.992524149s 18 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10205.020654585s 11 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10205.020654585s 11 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10205.022227859s 10 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10205.122545825s 4 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10205.122545825s 4 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10205.136375856s 92 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10205.136375856s 92 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10205.207854312s 28 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10205.207854312s 28 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10205.223155642s 56 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10205.223155642s 56 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10205.239128439s 61 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10205.239128439s 61 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10205.250311176s 7 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10205.279458444s 37 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10205.295305164s 76 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10205.295305164s 76 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10205.315543047s 87 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10205.350050972s 54 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10205.393276225s 75 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10205.414947269s 89 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10205.414947269s 89 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10205.444777482s 10 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10205.444777482s 10 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10205.477221438s 50 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10205.672860799s 7 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10205.672860799s 7 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10205.702008067s 37 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10205.702008067s 37 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10205.703356797s 45 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10205.707443552s 5 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10205.738092670s 87 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10205.738092670s 87 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10205.772600595s 54 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10205.772600595s 54 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10205.815825848s 75 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10205.815825848s 75 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10205.829108997s 68 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10205.899771061s 50 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10205.899771061s 50 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10205.906594458s 29 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10205.922390956s 55 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10205.969301782s 69 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10206.106216774s 52 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10206.125906420s 45 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10206.125906420s 45 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10206.129993175s 5 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10206.129993175s 5 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10206.187056916s 35 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10206.234250253s 63 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10206.246385709s 3 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10206.251658620s 68 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10206.251658620s 68 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10206.311883508s 39 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10206.329144081s 29 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10206.329144081s 29 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10206.344940579s 55 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10206.344940579s 55 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10206.391851405s 69 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10206.391851405s 69 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10206.528766397s 52 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10206.528766397s 52 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10206.609606539s 35 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10206.609606539s 35 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10206.610163465s 62 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10206.635934947s 81 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10206.656799876s 63 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10206.656799876s 63 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10206.657828945s 49 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10206.668935332s 3 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10206.668935332s 3 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10206.728972690s 27 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10206.733424500s 42 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10206.734433131s 39 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10206.734433131s 39 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10206.876886816s 33 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10206.894924750s 82 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10207.032713088s 62 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10207.032713088s 62 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10207.058484570s 81 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10207.058484570s 81 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10207.071271486s 73 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10207.080378568s 49 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10207.080378568s 49 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10207.106764800s 25 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10207.151522313s 27 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10207.151522313s 27 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10207.155974123s 42 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10207.155974123s 42 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10207.232750617s 57 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10207.260140141s 47 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10207.282732962s 15 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10207.299436439s 33 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10207.299436439s 33 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10207.317474373s 82 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10207.317474373s 82 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10207.328868387s 53 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10207.332027571s 84 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10207.336892974s 97 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10207.382789771s 6 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10207.437800711s 19 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10207.478362878s 70 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10207.493821109s 73 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10207.493821109s 73 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10207.508038928s 46 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10207.529314423s 25 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10207.529314423s 25 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10207.614729339s 65 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10207.655300240s 57 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10207.655300240s 57 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10207.682689764s 47 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10207.682689764s 47 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10207.705282585s 15 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10207.705282585s 15 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10207.743244709s 64 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10207.751168772s 48 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10207.751418010s 53 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10207.751418010s 53 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10207.754577194s 84 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10207.754577194s 84 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10207.759442597s 97 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10207.759442597s 97 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10207.805339394s 6 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10207.805339394s 6 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10207.860350334s 19 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10207.860350334s 19 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10207.900912501s 70 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10207.900912501s 70 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10207.930588551s 46 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10207.930588551s 46 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10207.944216368s 58 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10208.037278962s 65 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10208.037278962s 65 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10208.064733678s 9 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10208.165794332s 64 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10208.165794332s 64 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10208.173718395s 48 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10208.173718395s 48 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10208.366765991s 58 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10208.366765991s 58 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10208.487283301s 9 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10208.487283301s 9 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10208.812839667s 78 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10209.235389290s 78 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10209.235389290s 78 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10209.696067184s 95 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10210.118616807s 95 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10210.118616807s 95 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10212.385660639s 16 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10212.659066462s 74 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10212.808210262s 16 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10212.808210262s 16 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10213.081616085s 74 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10213.081616085s 74 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10216.461311568s 83 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10216.883861191s 83 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10216.883861191s 83 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++10226.331552573s 2 BNSKadcastNode:HandleChunkMessage(): [INFO ] Got all Chunks (ID: 11389160339061379072, prevID: 0, size: 1112867).
++10226.754102196s 2 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 11389160339061379072
++10226.754102196s 2 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 11389160339061379072
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10209957 - 1.0202e+07 =  7957 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10226331 - 1.0202e+07 =  24331 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205572 - 1.0202e+07 =  3572 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206246 - 1.0202e+07 =  4246 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204442 - 1.0202e+07 =  2442 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204699 - 1.0202e+07 =  2699 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205362 - 1.0202e+07 =  3362 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205707 - 1.0202e+07 =  3707 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205178 - 1.0202e+07 =  3178 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207382 - 1.0202e+07 =  5382 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204820 - 1.0202e+07 =  2820 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205250 - 1.0202e+07 =  3250 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203901 - 1.0202e+07 =  1901 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204344 - 1.0202e+07 =  2344 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207398 - 1.0202e+07 =  5398 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10208064 - 1.0202e+07 =  6064 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204651 - 1.0202e+07 =  2651 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205022 - 1.0202e+07 =  3022 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204384 - 1.0202e+07 =  2384 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204598 - 1.0202e+07 =  2598 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203510 - 1.0202e+07 =  1510 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203685 - 1.0202e+07 =  1685 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206960 - 1.0202e+07 =  4960 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207282 - 1.0202e+07 =  5282 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210772 - 1.0202e+07 =  8772 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10212385 - 1.0202e+07 =  10385 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204399 - 1.0202e+07 =  2399 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204569 - 1.0202e+07 =  2569 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207098 - 1.0202e+07 =  5098 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207437 - 1.0202e+07 =  5437 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10202000 - 1.0202e+07 =  0 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10202000 - 1.0202e+07 =  0 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203671 - 1.0202e+07 =  1671 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204055 - 1.0202e+07 =  2055 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203242 - 1.0202e+07 =  1242 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203417 - 1.0202e+07 =  1417 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206885 - 1.0202e+07 =  4885 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207106 - 1.0202e+07 =  5106 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10202077 - 1.0202e+07 =  77 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10202363 - 1.0202e+07 =  363 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206399 - 1.0202e+07 =  4399 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206728 - 1.0202e+07 =  4728 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204597 - 1.0202e+07 =  2597 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204785 - 1.0202e+07 =  2785 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205687 - 1.0202e+07 =  3687 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205906 - 1.0202e+07 =  3906 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10202431 - 1.0202e+07 =  431 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10202718 - 1.0202e+07 =  718 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203032 - 1.0202e+07 =  1032 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203207 - 1.0202e+07 =  1207 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206656 - 1.0202e+07 =  4656 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206876 - 1.0202e+07 =  4876 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204018 - 1.0202e+07 =  2018 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204159 - 1.0202e+07 =  2159 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205968 - 1.0202e+07 =  3968 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206187 - 1.0202e+07 =  4187 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204937 - 1.0202e+07 =  2937 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205279 - 1.0202e+07 =  3279 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203153 - 1.0202e+07 =  1153 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203583 - 1.0202e+07 =  1583 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206146 - 1.0202e+07 =  4146 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206311 - 1.0202e+07 =  4311 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203900 - 1.0202e+07 =  1900 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204162 - 1.0202e+07 =  2162 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203868 - 1.0202e+07 =  1868 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204154 - 1.0202e+07 =  2154 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206514 - 1.0202e+07 =  4514 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206733 - 1.0202e+07 =  4733 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205526 - 1.0202e+07 =  3526 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205703 - 1.0202e+07 =  3703 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207177 - 1.0202e+07 =  5177 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207508 - 1.0202e+07 =  5508 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207083 - 1.0202e+07 =  5083 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207260 - 1.0202e+07 =  5260 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207262 - 1.0202e+07 =  5262 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207751 - 1.0202e+07 =  5751 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206562 - 1.0202e+07 =  4562 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206657 - 1.0202e+07 =  4657 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205226 - 1.0202e+07 =  3226 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205477 - 1.0202e+07 =  3477 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205940 - 1.0202e+07 =  3940 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206106 - 1.0202e+07 =  4106 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206203 - 1.0202e+07 =  4203 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207328 - 1.0202e+07 =  5328 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205137 - 1.0202e+07 =  3137 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205350 - 1.0202e+07 =  3350 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205550 - 1.0202e+07 =  3550 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205922 - 1.0202e+07 =  3922 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204670 - 1.0202e+07 =  2670 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204800 - 1.0202e+07 =  2800 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206827 - 1.0202e+07 =  4827 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207232 - 1.0202e+07 =  5232 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207233 - 1.0202e+07 =  5233 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207944 - 1.0202e+07 =  5944 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10202799 - 1.0202e+07 =  799 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203774 - 1.0202e+07 =  1774 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203288 - 1.0202e+07 =  1288 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203733 - 1.0202e+07 =  1733 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204597 - 1.0202e+07 =  2597 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204816 - 1.0202e+07 =  2816 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205895 - 1.0202e+07 =  3895 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206610 - 1.0202e+07 =  4610 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205846 - 1.0202e+07 =  3846 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206234 - 1.0202e+07 =  4234 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206352 - 1.0202e+07 =  4352 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207743 - 1.0202e+07 =  5743 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206336 - 1.0202e+07 =  4336 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207614 - 1.0202e+07 =  5614 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205562 - 1.0202e+07 =  3562 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205829 - 1.0202e+07 =  3829 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205744 - 1.0202e+07 =  3744 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205969 - 1.0202e+07 =  3969 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207183 - 1.0202e+07 =  5183 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207478 - 1.0202e+07 =  5478 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206820 - 1.0202e+07 =  4820 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207071 - 1.0202e+07 =  5071 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10211937 - 1.0202e+07 =  9937 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10212659 - 1.0202e+07 =  10659 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204620 - 1.0202e+07 =  2620 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205393 - 1.0202e+07 =  3393 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204586 - 1.0202e+07 =  2586 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204872 - 1.0202e+07 =  2872 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10208048 - 1.0202e+07 =  6048 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10208812 - 1.0202e+07 =  6812 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206267 - 1.0202e+07 =  4267 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206635 - 1.0202e+07 =  4635 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206477 - 1.0202e+07 =  4477 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206894 - 1.0202e+07 =  4894 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10214845 - 1.0202e+07 =  12845 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10216461 - 1.0202e+07 =  14461 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207054 - 1.0202e+07 =  5054 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207332 - 1.0202e+07 =  5332 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203783 - 1.0202e+07 =  1783 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204212 - 1.0202e+07 =  2212 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204181 - 1.0202e+07 =  2181 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205315 - 1.0202e+07 =  3315 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10202795 - 1.0202e+07 =  795 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203747 - 1.0202e+07 =  1747 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204600 - 1.0202e+07 =  2600 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204992 - 1.0202e+07 =  2992 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204334 - 1.0202e+07 =  2334 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10204713 - 1.0202e+07 =  2713 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10208116 - 1.0202e+07 =  6116 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10209696 - 1.0202e+07 =  7696 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206658 - 1.0202e+07 =  4658 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207336 - 1.0202e+07 =  5336 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] total_ttfb: 266704
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] total_ttlb: 317708
++43200.000000000s -1 BNS:collectPropagationData(): [DEBUG] TTFBs size: 73
++43200.000000000s -1 BNS:collectPropagationData(): [DEBUG] TTLBs size: 73
++43200.000000000s -1 BNS:collectPropagationData(): [DEBUG] Avg. TTFB: 3653
++43200.000000000s -1 BNS:collectPropagationData(): [DEBUG] Avg. TTLB: 4352
++43200.000000000s -1 BNS:collectPropagationData(): [DEBUG] Median TTFB: 3562
++43200.000000000s -1 BNS:collectPropagationData(): [DEBUG] Median TTLB: 3922
++43200.000000000s -1 BNS:collectPropagationData(): [DEBUG] Coverage: 0.73
++43200.000000000s -1 BNS:collectTrafficData(): [INFO ] Total number of mined blocks: 1, top block Height: 1
++43200.000000000s -1 BNS:collectTrafficData(): [INFO ] Stale rate: 0, totalTraffic: 6.91791e+08, overheadRatio: 5.27908
+BNS:main(): [INFO ] Simulation finished!

--- a/bns/logs/vanilla.log
+++ b/bns/logs/vanilla.log
@@ -1,0 +1,5215 @@
+Waf: Entering directory `/root/ns3/ns3-allinone-build-version/ns-3-dev/build'
+Waf: Leaving directory `/root/ns3/ns3-allinone-build-version/ns-3-dev/build'
+Build commands will be stored in build/compile_commands.json
+'build' finished successfully (2.093s)
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 1(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 120.173
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 8.88921
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 18.6517
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 2(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 0.568956
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 5.83134
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 6.23416
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 3(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 13.8093
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 26.4436
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 11.9251
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 4(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 36.0853
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 0.246853
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 5.57218
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 5(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 26.9462
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 14.123
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 8.82795
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 6(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 47.3436
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 7.80331
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 2.33644
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 7(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 31.4452
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 10.7516
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 14.2873
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 8(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 21.0406
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 0.0447379
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 4.77584
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 9(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 13.9878
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 6.89135
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 1.11436
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 10(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 25.0756
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 20.331
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 7.36613
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 11(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 43.5417
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 22.008
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 12.5514
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 12(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 12.0406
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 21.7329
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 16.4545
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 13(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 81.8338
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 24.3911
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 13.6484
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 14(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 55.3613
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 0.573648
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 16.4218
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 15(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 28.9562
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 17.6066
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 20.923
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 16(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 34.3309
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 16.415
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 16.9496
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 17(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 58.5002
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 27.2036
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 8.87262
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 18(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 54.5194
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 27.6424
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 14.2451
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 19(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 63.1409
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 1.53098
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 7.02345
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 20(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 59.4948
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 13.2326
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 23.1538
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 21(NA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 17.3457
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 32.5167
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 21.5968
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 23(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 24.2395
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 20.2939
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 1.40567
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 24(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 80.1656
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 71.5714
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 10.3862
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 25(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 63.3821
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 24.0193
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 4.28825
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 26(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 81.886
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 53.2797
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 9.06935
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 27(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 62.7373
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 49.2004
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 5.20838
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 28(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 49.6386
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 34.845
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 14.2946
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 29(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 55.0728
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 28.1114
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 4.94118
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 30(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 103.894
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 21.6628
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 5.68566
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 31(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 62.4758
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 50.5346
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 10.7704
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 32(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 104.946
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 8.00848
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 18.7409
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 33(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 46.563
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 36.2011
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 50.9865
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 34(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 66.761
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 0.433148
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 5.25549
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 35(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 60.6823
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 27.4568
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 11.4635
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 36(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 50.0394
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 88.2833
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 8.0401
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 37(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 37.2014
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 56.876
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 9.87873
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 38(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 87.0679
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 0.693451
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 6.40138
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 39(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 66.0045
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 8.20296
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 11.9416
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 40(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 35.5545
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 37.077
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 11.9624
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 41(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 77.0539
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 42.5116
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 9.20812
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 42(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 108.086
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 28.811
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 9.99615
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 43(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 52.1376
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 44.0088
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 66.9788
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 44(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 84.3963
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 43.8716
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 12.2545
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 45(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 85.518
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 25.3317
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 5.37523
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 46(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 79.7461
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 29.4248
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 13.7694
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 47(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 81.5398
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 38.3988
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 12.2935
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 48(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 19.0322
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 43.9584
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 5.36659
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 49(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 109.514
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 73.6877
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 20.5007
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 50(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 59.0666
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 60.598
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 0.520477
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 51(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 52.3795
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 20.3082
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 12.1624
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 52(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 99.778
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 97.8526
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 13.2369
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 53(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 8.26582
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 51.7863
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 16.0015
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 54(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 122.329
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 42.1379
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 2.76628
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 55(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 25.0075
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 51.5596
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 10.172
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 56(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 87.8781
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 42.7979
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 6.17589
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 57(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 87.1286
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 36.806
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 13.6092
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 58(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 13.1089
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 14.6666
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 4.72991
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 59(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 9.55396
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 48.0387
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 2.80014
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 60(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 20.93
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 44.0098
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 145.905
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 61(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 57.1988
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 11.7346
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 10.7725
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 62(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 17.6429
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 43.7953
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 4.07978
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 63(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 118.061
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 5.76752
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 11.4383
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 64(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 6.69103
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 26.4434
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 16.2261
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 65(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 7.27829
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 60.1724
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 6.14795
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 66(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 95.7612
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 49.5386
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 6.63352
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 67(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 98.2182
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 48.5236
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 4.55957
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 68(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 58.6956
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 37.2186
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 5.13018
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 69(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 41.3491
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 28.258
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 1.6225
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 70(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 35.827
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 50.2461
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 25.428
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 71(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 76.4396
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 44.6068
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 9.96941
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 72(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 80.9808
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 11.9823
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 7.66905
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 73(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 37.661
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 45.9292
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 23.8808
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 74(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 60.4349
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 8.09944
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 1.28072
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 75(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 63.0751
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 36.4004
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 6.64156
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 76(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 106.759
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 56.2896
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 11.3263
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 77(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 50.9426
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 14.2738
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 9.5388
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 78(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 12.5058
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 35.932
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 3.58745
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 79(EU):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 46.6411
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 47.3779
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 2.79725
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 81(AS):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 25.2564
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 23.9413
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 1.7325
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 82(AS):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 31.1365
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 12.9002
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 6.80114
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 83(AS):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 49.4199
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 9.95112
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 1.20631
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 84(AS):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 57.8697
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 25.2836
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 34.5997
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 85(AS):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 89.797
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 68.8117
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 87.0584
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 86(AS):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 93.0964
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 34.3513
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 1.17414
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 87(AS):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 8.20801
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 45.874
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 3.30064
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 88(AS):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 9.77014
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 111.056
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 0.93658
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 89(AS):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 23.7282
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 52.6017
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 8.76698
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 90(AS):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 33.8779
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 27.9081
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 84.4558
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 92(OC):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 27.8908
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 22.9889
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 9.49478
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 93(OC):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 4.02685
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 1.36615
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 1.153
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 95(AF):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 5.88962
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 7.59419
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 97.3127
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 97(SA):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 13.7111
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 7.15242
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 58.0925
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 99(CN):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 93.7893
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 77.4536
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 7.42191
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 100(CN):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 168.322
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 68.0679
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 1.17163
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 101(CN):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 126.021
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 57.6436
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 4.38055
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 102(CN):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 205.426
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 114.544
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 3.83817
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 103(CN):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 133.11
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 105.928
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 80.9099
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 104(CN):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 66.6997
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 166.014
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 0.333463
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 105(CN):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 136.144
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 78.2486
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 0.570304
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Node 106(CN):
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting downloadRate: 237.689
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting uploadRate: 40.0844
++0.000000000s -1 BNSBitcoinTopologyHelper:ConnectRegionLeafs(): [INFO ] Setting linkDelay: 3.76867
++0.000000000s -1 BNSBitcoinTopologyHelper:BitcoinTopologyHelper(): [INFO ] All Continents successfully connected
++0.000000000s -1 BNSBitcoinTopologyHelper:BitcoinTopologyHelper(): [INFO ] Amount of Nodes in each Continent:
++0.000000000s -1 BNSBitcoinTopologyHelper:BitcoinTopologyHelper(): [INFO ] NA: 21
++0.000000000s -1 BNSBitcoinTopologyHelper:BitcoinTopologyHelper(): [INFO ] EU: 57
++0.000000000s -1 BNSBitcoinTopologyHelper:BitcoinTopologyHelper(): [INFO ] AS: 10
++0.000000000s -1 BNSBitcoinTopologyHelper:BitcoinTopologyHelper(): [INFO ] OC: 2
++0.000000000s -1 BNSBitcoinTopologyHelper:BitcoinTopologyHelper(): [INFO ] AF: 1
++0.000000000s -1 BNSBitcoinTopologyHelper:BitcoinTopologyHelper(): [INFO ] SA: 1
++0.000000000s -1 BNSBitcoinTopologyHelper:BitcoinTopologyHelper(): [INFO ] CN: 8
++0.000000000s -1 BNSBitcoinTopologyHelper:BitcoinTopologyHelper(): [INFO ] TOTAL: 100
++0.000000000s -1 BNS:main(): [INFO ] Marked 0 nodes as byzantine.
++0.000000000s -1 BNS:main(): [INFO ] Running Simulator!
++2.000000000s 1 BNSMincastNode:StartApplication(): [INFO ] Starting node 1: 10.1.0.1
++2.000000000s 1 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++2.000000000s 2 BNSMincastNode:StartApplication(): [INFO ] Starting node 2: 10.1.0.2
++2.000000000s 2 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.47
++2.000000000s 3 BNSMincastNode:StartApplication(): [INFO ] Starting node 3: 10.1.0.3
++2.000000000s 3 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.16
++2.000000000s 4 BNSMincastNode:StartApplication(): [INFO ] Starting node 4: 10.1.0.4
++2.000000000s 4 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.5
++2.000000000s 5 BNSMincastNode:StartApplication(): [INFO ] Starting node 5: 10.1.0.5
++2.000000000s 5 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.19
++2.000000000s 6 BNSMincastNode:StartApplication(): [INFO ] Starting node 6: 10.1.0.6
++2.000000000s 6 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.10
++2.000000000s 7 BNSMincastNode:StartApplication(): [INFO ] Starting node 7: 10.1.0.7
++2.000000000s 7 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.9.0.1
++2.000000000s 8 BNSMincastNode:StartApplication(): [INFO ] Starting node 8: 10.1.0.8
++2.000000000s 8 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++2.000000000s 9 BNSMincastNode:StartApplication(): [INFO ] Starting node 9: 10.1.0.9
++2.000000000s 9 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.30
++2.000000000s 10 BNSMincastNode:StartApplication(): [INFO ] Starting node 10: 10.1.0.10
++2.000000000s 10 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.3
++2.000000000s 11 BNSMincastNode:StartApplication(): [INFO ] Starting node 11: 10.1.0.11
++2.000000000s 11 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++2.000000000s 12 BNSMincastNode:StartApplication(): [INFO ] Starting node 12: 10.1.0.12
++2.000000000s 12 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++2.000000000s 13 BNSMincastNode:StartApplication(): [INFO ] Starting node 13: 10.1.0.13
++2.000000000s 13 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.32
++2.000000000s 14 BNSMincastNode:StartApplication(): [INFO ] Starting node 14: 10.1.0.14
++2.000000000s 15 BNSMincastNode:StartApplication(): [INFO ] Starting node 15: 10.1.0.15
++2.000000000s 15 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.24
++2.000000000s 16 BNSMincastNode:StartApplication(): [INFO ] Starting node 16: 10.1.0.16
++2.000000000s 16 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.30
++2.000000000s 17 BNSMincastNode:StartApplication(): [INFO ] Starting node 17: 10.1.0.17
++2.000000000s 17 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.5
++2.000000000s 18 BNSMincastNode:StartApplication(): [INFO ] Starting node 18: 10.1.0.18
++2.000000000s 18 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.5
++2.000000000s 19 BNSMincastNode:StartApplication(): [INFO ] Starting node 19: 10.1.0.19
++2.000000000s 19 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.10
++2.000000000s 20 BNSMincastNode:StartApplication(): [INFO ] Starting node 20: 10.1.0.20
++2.000000000s 20 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.19
++2.000000000s 21 BNSMincastNode:StartApplication(): [INFO ] Starting node 21: 10.1.0.21
++2.000000000s 23 BNSMincastNode:StartApplication(): [INFO ] Starting node 23: 10.3.0.1
++2.000000000s 23 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.57
++2.000000000s 24 BNSMincastNode:StartApplication(): [INFO ] Starting node 24: 10.3.0.2
++2.000000000s 24 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.21
++2.000000000s 25 BNSMincastNode:StartApplication(): [INFO ] Starting node 25: 10.3.0.3
++2.000000000s 25 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.21
++2.000000000s 26 BNSMincastNode:StartApplication(): [INFO ] Starting node 26: 10.3.0.4
++2.000000000s 26 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.19
++2.000000000s 27 BNSMincastNode:StartApplication(): [INFO ] Starting node 27: 10.3.0.5
++2.000000000s 27 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.5
++2.000000000s 28 BNSMincastNode:StartApplication(): [INFO ] Starting node 28: 10.3.0.6
++2.000000000s 28 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.42
++2.000000000s 29 BNSMincastNode:StartApplication(): [INFO ] Starting node 29: 10.3.0.7
++2.000000000s 30 BNSMincastNode:StartApplication(): [INFO ] Starting node 30: 10.3.0.8
++2.000000000s 30 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.2
++2.000000000s 31 BNSMincastNode:StartApplication(): [INFO ] Starting node 31: 10.3.0.9
++2.000000000s 31 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.6
++2.000000000s 32 BNSMincastNode:StartApplication(): [INFO ] Starting node 32: 10.3.0.10
++2.000000000s 32 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.9
++2.000000000s 33 BNSMincastNode:StartApplication(): [INFO ] Starting node 33: 10.3.0.11
++2.000000000s 33 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.8
++2.000000000s 34 BNSMincastNode:StartApplication(): [INFO ] Starting node 34: 10.3.0.12
++2.000000000s 34 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++2.000000000s 35 BNSMincastNode:StartApplication(): [INFO ] Starting node 35: 10.3.0.13
++2.000000000s 35 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++2.000000000s 36 BNSMincastNode:StartApplication(): [INFO ] Starting node 36: 10.3.0.14
++2.000000000s 36 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.12
++2.000000000s 37 BNSMincastNode:StartApplication(): [INFO ] Starting node 37: 10.3.0.15
++2.000000000s 37 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.24
++2.000000000s 38 BNSMincastNode:StartApplication(): [INFO ] Starting node 38: 10.3.0.16
++2.000000000s 38 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.51
++2.000000000s 39 BNSMincastNode:StartApplication(): [INFO ] Starting node 39: 10.3.0.17
++2.000000000s 39 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.3
++2.000000000s 40 BNSMincastNode:StartApplication(): [INFO ] Starting node 40: 10.3.0.18
++2.000000000s 40 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.15
++2.000000000s 41 BNSMincastNode:StartApplication(): [INFO ] Starting node 41: 10.3.0.19
++2.000000000s 41 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.7
++2.000000000s 42 BNSMincastNode:StartApplication(): [INFO ] Starting node 42: 10.3.0.20
++2.000000000s 42 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.47
++2.000000000s 43 BNSMincastNode:StartApplication(): [INFO ] Starting node 43: 10.3.0.21
++2.000000000s 43 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.23
++2.000000000s 44 BNSMincastNode:StartApplication(): [INFO ] Starting node 44: 10.3.0.22
++2.000000000s 44 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.35
++2.000000000s 45 BNSMincastNode:StartApplication(): [INFO ] Starting node 45: 10.3.0.23
++2.000000000s 45 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++2.000000000s 46 BNSMincastNode:StartApplication(): [INFO ] Starting node 46: 10.3.0.24
++2.000000000s 46 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++2.000000000s 47 BNSMincastNode:StartApplication(): [INFO ] Starting node 47: 10.3.0.25
++2.000000000s 47 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.24
++2.000000000s 48 BNSMincastNode:StartApplication(): [INFO ] Starting node 48: 10.3.0.26
++2.000000000s 48 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.2
++2.000000000s 49 BNSMincastNode:StartApplication(): [INFO ] Starting node 49: 10.3.0.27
++2.000000000s 50 BNSMincastNode:StartApplication(): [INFO ] Starting node 50: 10.3.0.28
++2.000000000s 50 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.10
++2.000000000s 51 BNSMincastNode:StartApplication(): [INFO ] Starting node 51: 10.3.0.29
++2.000000000s 51 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++2.000000000s 52 BNSMincastNode:StartApplication(): [INFO ] Starting node 52: 10.3.0.30
++2.000000000s 52 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++2.000000000s 53 BNSMincastNode:StartApplication(): [INFO ] Starting node 53: 10.3.0.31
++2.000000000s 53 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++2.000000000s 54 BNSMincastNode:StartApplication(): [INFO ] Starting node 54: 10.3.0.32
++2.000000000s 54 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.25
++2.000000000s 55 BNSMincastNode:StartApplication(): [INFO ] Starting node 55: 10.3.0.33
++2.000000000s 55 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.9
++2.000000000s 56 BNSMincastNode:StartApplication(): [INFO ] Starting node 56: 10.3.0.34
++2.000000000s 56 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.17
++2.000000000s 57 BNSMincastNode:StartApplication(): [INFO ] Starting node 57: 10.3.0.35
++2.000000000s 57 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.51
++2.000000000s 58 BNSMincastNode:StartApplication(): [INFO ] Starting node 58: 10.3.0.36
++2.000000000s 58 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.21
++2.000000000s 59 BNSMincastNode:StartApplication(): [INFO ] Starting node 59: 10.3.0.37
++2.000000000s 59 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.41
++2.000000000s 60 BNSMincastNode:StartApplication(): [INFO ] Starting node 60: 10.3.0.38
++2.000000000s 60 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.4
++2.000000000s 61 BNSMincastNode:StartApplication(): [INFO ] Starting node 61: 10.3.0.39
++2.000000000s 61 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.48
++2.000000000s 62 BNSMincastNode:StartApplication(): [INFO ] Starting node 62: 10.3.0.40
++2.000000000s 62 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.22
++2.000000000s 63 BNSMincastNode:StartApplication(): [INFO ] Starting node 63: 10.3.0.41
++2.000000000s 63 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.34
++2.000000000s 64 BNSMincastNode:StartApplication(): [INFO ] Starting node 64: 10.3.0.42
++2.000000000s 64 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.11
++2.000000000s 65 BNSMincastNode:StartApplication(): [INFO ] Starting node 65: 10.3.0.43
++2.000000000s 65 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.3
++2.000000000s 66 BNSMincastNode:StartApplication(): [INFO ] Starting node 66: 10.3.0.44
++2.000000000s 66 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.46
++2.000000000s 67 BNSMincastNode:StartApplication(): [INFO ] Starting node 67: 10.3.0.45
++2.000000000s 67 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.11
++2.000000000s 68 BNSMincastNode:StartApplication(): [INFO ] Starting node 68: 10.3.0.46
++2.000000000s 68 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++2.000000000s 69 BNSMincastNode:StartApplication(): [INFO ] Starting node 69: 10.3.0.47
++2.000000000s 69 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.4
++2.000000000s 70 BNSMincastNode:StartApplication(): [INFO ] Starting node 70: 10.3.0.48
++2.000000000s 70 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++2.000000000s 71 BNSMincastNode:StartApplication(): [INFO ] Starting node 71: 10.3.0.49
++2.000000000s 71 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.18
++2.000000000s 72 BNSMincastNode:StartApplication(): [INFO ] Starting node 72: 10.3.0.50
++2.000000000s 72 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.24
++2.000000000s 73 BNSMincastNode:StartApplication(): [INFO ] Starting node 73: 10.3.0.51
++2.000000000s 73 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.34
++2.000000000s 74 BNSMincastNode:StartApplication(): [INFO ] Starting node 74: 10.3.0.52
++2.000000000s 74 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.56
++2.000000000s 75 BNSMincastNode:StartApplication(): [INFO ] Starting node 75: 10.3.0.53
++2.000000000s 75 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.7
++2.000000000s 76 BNSMincastNode:StartApplication(): [INFO ] Starting node 76: 10.3.0.54
++2.000000000s 76 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.10
++2.000000000s 77 BNSMincastNode:StartApplication(): [INFO ] Starting node 77: 10.3.0.55
++2.000000000s 77 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.24
++2.000000000s 78 BNSMincastNode:StartApplication(): [INFO ] Starting node 78: 10.3.0.56
++2.000000000s 78 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.8
++2.000000000s 79 BNSMincastNode:StartApplication(): [INFO ] Starting node 79: 10.3.0.57
++2.000000000s 79 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.43
++2.000000000s 81 BNSMincastNode:StartApplication(): [INFO ] Starting node 81: 10.5.0.1
++2.000000000s 81 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++2.000000000s 82 BNSMincastNode:StartApplication(): [INFO ] Starting node 82: 10.5.0.2
++2.000000000s 82 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.9
++2.000000000s 83 BNSMincastNode:StartApplication(): [INFO ] Starting node 83: 10.5.0.3
++2.000000000s 83 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.9
++2.000000000s 84 BNSMincastNode:StartApplication(): [INFO ] Starting node 84: 10.5.0.4
++2.000000000s 84 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.7
++2.000000000s 85 BNSMincastNode:StartApplication(): [INFO ] Starting node 85: 10.5.0.5
++2.000000000s 85 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.21
++2.000000000s 86 BNSMincastNode:StartApplication(): [INFO ] Starting node 86: 10.5.0.6
++2.000000000s 86 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.9
++2.000000000s 87 BNSMincastNode:StartApplication(): [INFO ] Starting node 87: 10.5.0.7
++2.000000000s 87 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.16
++2.000000000s 88 BNSMincastNode:StartApplication(): [INFO ] Starting node 88: 10.5.0.8
++2.000000000s 88 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.3
++2.000000000s 89 BNSMincastNode:StartApplication(): [INFO ] Starting node 89: 10.5.0.9
++2.000000000s 89 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.16
++2.000000000s 90 BNSMincastNode:StartApplication(): [INFO ] Starting node 90: 10.5.0.10
++2.000000000s 90 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++2.000000000s 92 BNSMincastNode:StartApplication(): [INFO ] Starting node 92: 10.7.0.1
++2.000000000s 92 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.11
++2.000000000s 93 BNSMincastNode:StartApplication(): [INFO ] Starting node 93: 10.7.0.2
++2.000000000s 93 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.5
++2.000000000s 95 BNSMincastNode:StartApplication(): [INFO ] Starting node 95: 10.9.0.1
++2.000000000s 95 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.44
++2.000000000s 97 BNSMincastNode:StartApplication(): [INFO ] Starting node 97: 10.11.0.1
++2.000000000s 97 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.1
++2.000000000s 99 BNSMincastNode:StartApplication(): [INFO ] Starting node 99: 10.13.0.1
++2.000000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.12
++2.000000000s 100 BNSMincastNode:StartApplication(): [INFO ] Starting node 100: 10.13.0.2
++2.000000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.4
++2.000000000s 101 BNSMincastNode:StartApplication(): [INFO ] Starting node 101: 10.13.0.3
++2.000000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.6
++2.000000000s 102 BNSMincastNode:StartApplication(): [INFO ] Starting node 102: 10.13.0.4
++2.000000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.55
++2.000000000s 103 BNSMincastNode:StartApplication(): [INFO ] Starting node 103: 10.13.0.5
++2.000000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.19
++2.000000000s 104 BNSMincastNode:StartApplication(): [INFO ] Starting node 104: 10.13.0.6
++2.000000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.46
++2.000000000s 105 BNSMincastNode:StartApplication(): [INFO ] Starting node 105: 10.13.0.7
++2.000000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.1
++2.000000000s 106 BNSMincastNode:StartApplication(): [INFO ] Starting node 106: 10.13.0.8
++2.000000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.22
++2.004393460s 88 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.3
++2.006548978s 83 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.8
++2.008467583s 23 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.57
++2.009851317s 74 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.56
++2.012701050s 79 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.1
++2.014807366s 78 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.52
++2.016004696s 105 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.1
++2.017981609s 79 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.43
++2.019929104s 86 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.9
++2.021677944s 68 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.8
++2.022022742s 34 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.5
++2.023210513s 75 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.7
++2.023285339s 42 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.47
++2.023561980s 66 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.46
++2.024007033s 99 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.7
++2.025804921s 35 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.1
++2.026995284s 65 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.57
++2.027683876s 36 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.12
++2.028619568s 59 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.41
++2.029901004s 89 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.6
++2.030152053s 54 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.25
++2.030742864s 4 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.5
++2.032063306s 5 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.19
++2.032509553s 30 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.46
++2.032721506s 62 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.22
++2.033490846s 27 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.12
++2.034812965s 29 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.53
++2.034929431s 69 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.20
++2.035328973s 63 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.34
++2.035341759s 68 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.44
++2.035476200s 17 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.5
++2.036314732s 56 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.17
++2.036586259s 26 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.19
++2.038707661s 23 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.13
++2.040990825s 34 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.14
++2.042870701s 63 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.37
++2.042943008s 72 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.24
++2.043728480s 40 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.15
++2.043905669s 71 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.18
++2.045227341s 47 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.32
++2.046221554s 18 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.5
++2.046679669s 77 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.24
++2.046909060s 5 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.4
++2.047338554s 37 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.24
++2.047450679s 53 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.50
++2.047952141s 19 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.5
++2.049070758s 44 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.40
++2.051761440s 44 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.35
++2.052165153s 47 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.24
++2.053023026s 56 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.41
++2.053208681s 5 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.17
++2.054448879s 39 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.34
++2.054877448s 41 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.4
++2.059101712s 32 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.9
++2.060151933s 73 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.34
++2.061150799s 28 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.42
++2.061261224s 38 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.51
++2.061311752s 70 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.5
++2.064422963s 46 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.50
++2.065592886s 37 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.18
++2.065859320s 40 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.49
++2.069326306s 5 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.18
++2.070023585s 46 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.55
++2.070999735s 46 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.15
++2.071134921s 72 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.31
++2.072470850s 61 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.48
++2.075020401s 57 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.51
++2.077639962s 57 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.22
++2.078244717s 46 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.25
++2.088673941s 31 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.10
++2.090222948s 56 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.51
++2.091748382s 64 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.6
++2.091963605s 27 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.48
++2.092177843s 73 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.16
++2.100000000s 1 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++2.100000000s 2 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.18
++2.100000000s 3 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.7
++2.100000000s 4 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.57
++2.100000000s 5 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.3
++2.100000000s 6 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.54
++2.100000000s 7 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.37
++2.100000000s 8 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.7
++2.100000000s 9 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.41
++2.100000000s 10 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.19
++2.100000000s 11 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.47
++2.100000000s 12 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.2
++2.100000000s 14 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.33
++2.100000000s 15 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++2.100000000s 16 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.28
++2.100000000s 17 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.14
++2.100000000s 18 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.3
++2.100000000s 19 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++2.100000000s 20 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.42
++2.100000000s 21 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.53
++2.100000000s 23 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.48
++2.100000000s 24 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++2.100000000s 25 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.18
++2.100000000s 26 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.15
++2.100000000s 27 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.9
++2.100000000s 28 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++2.100000000s 29 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.2
++2.100000000s 30 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++2.100000000s 31 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.31
++2.100000000s 32 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++2.100000000s 33 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.13
++2.100000000s 34 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.43
++2.100000000s 35 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.21
++2.100000000s 36 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++2.100000000s 37 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++2.100000000s 38 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.13
++2.100000000s 39 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.20
++2.100000000s 40 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.51
++2.100000000s 41 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.14
++2.100000000s 42 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.19
++2.100000000s 43 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.3
++2.100000000s 44 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++2.100000000s 45 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++2.100000000s 46 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.40
++2.100000000s 47 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.3
++2.100000000s 48 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.17
++2.100000000s 49 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++2.100000000s 50 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.46
++2.100000000s 51 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.6
++2.100000000s 52 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.6
++2.100000000s 53 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++2.100000000s 54 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.13
++2.100000000s 55 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.14
++2.100000000s 56 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.26
++2.100000000s 57 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.18
++2.100000000s 58 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++2.100000000s 59 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.1
++2.100000000s 60 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.3
++2.100000000s 61 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.56
++2.100000000s 62 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.30
++2.100000000s 63 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.15
++2.100000000s 64 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.2
++2.100000000s 65 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.9
++2.100000000s 66 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.51
++2.100000000s 67 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++2.100000000s 68 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++2.100000000s 69 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++2.100000000s 70 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++2.100000000s 71 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.54
++2.100000000s 72 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.34
++2.100000000s 73 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.30
++2.100000000s 74 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.48
++2.100000000s 75 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.20
++2.100000000s 76 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.1
++2.100000000s 77 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.5
++2.100000000s 78 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.14
++2.100000000s 79 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.17
++2.100000000s 81 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.9
++2.100000000s 82 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.39
++2.100000000s 83 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++2.100000000s 84 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.4
++2.100000000s 85 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.17
++2.100000000s 86 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.1
++2.100000000s 87 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.9
++2.100000000s 88 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.32
++2.100000000s 89 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.4
++2.100000000s 90 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++2.100000000s 92 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.8
++2.100000000s 93 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++2.100000000s 95 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.9
++2.100000000s 97 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.55
++2.100000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.8
++2.100000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.13
++2.100000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.4
++2.100000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++2.100000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.18
++2.100000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++2.100000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.26
++2.100000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.30
++2.107830052s 50 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.10
++2.108636051s 2 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.47
++2.108720227s 70 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.39
++2.111129307s 67 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.11
++2.111337195s 50 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.46
++2.112533632s 73 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.35
++2.114700680s 55 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.9
++2.116455470s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.4
++2.117002339s 68 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.28
++2.118299624s 31 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.6
++2.120812426s 9 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.30
++2.121065088s 81 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.9
++2.122405618s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.8
++2.123136023s 56 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.26
++2.123319634s 78 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.14
++2.123956519s 34 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.43
++2.124683782s 102 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.3
++2.124868861s 13 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.32
++2.127750459s 72 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.34
++2.128498939s 54 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.13
++2.128531786s 11 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.8
++2.128817598s 61 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.56
++2.129130913s 10 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.19
++2.129378528s 3 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.16
++2.129438715s 76 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.10
++2.129561066s 79 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.17
++2.130293435s 68 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.20
++2.131175309s 37 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.8
++2.131600819s 89 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.1
++2.131957932s 8 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.20
++2.131991082s 27 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.9
++2.133207830s 47 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.3
++2.133490025s 67 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.29
++2.133603589s 106 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++2.134286350s 6 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.10
++2.134527900s 41 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.14
++2.134534911s 64 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.11
++2.134679644s 62 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.30
++2.134711298s 48 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.34
++2.134735677s 48 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.17
++2.134967835s 36 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.56
++2.135756901s 46 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.40
++2.136416662s 65 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.12
++2.136466178s 55 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.14
++2.137931178s 26 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.15
++2.139907613s 44 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.50
++2.140351502s 12 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.50
++2.140451318s 36 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.29
++2.141636370s 56 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.50
++2.142135346s 81 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.7
++2.142384529s 52 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.3
++2.142501718s 53 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.5
++2.142620412s 71 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.54
++2.142746105s 35 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.32
++2.143248920s 78 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.39
++2.143503893s 58 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.21
++2.143548585s 19 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.10
++2.143837670s 25 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.21
++2.144315595s 39 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.57
++2.144751243s 43 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.23
++2.145435372s 42 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.46
++2.146751459s 30 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.15
++2.147985601s 31 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.5
++2.149807605s 25 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.25
++2.150229191s 51 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.45
++2.151186761s 57 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.18
++2.151794913s 36 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.19
++2.152010517s 52 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.40
++2.152060254s 39 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.26
++2.152424246s 16 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.30
++2.153504569s 74 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.48
++2.153625622s 31 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.31
++2.153645278s 62 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.24
++2.153731503s 23 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.48
++2.154695238s 36 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.33
++2.156019220s 24 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.21
++2.156783704s 20 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.19
++2.156898985s 37 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.4
++2.157971266s 1 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.6
++2.159846337s 72 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.22
++2.160667001s 51 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.14
++2.161065273s 66 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.51
++2.161448889s 15 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.24
++2.161503374s 89 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.16
++2.161741014s 10 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.28
++2.162577236s 69 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.2
++2.163726844s 27 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.31
++2.163929818s 76 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.49
++2.166693606s 33 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.45
++2.169623629s 28 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.27
++2.171734408s 40 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.51
++2.172026255s 9 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.33
++2.174267225s 73 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.30
++2.176782281s 40 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.35
++2.177424174s 6 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.9
++2.180278673s 70 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.52
++2.180458394s 53 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.9
++2.180598503s 70 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.1
++2.181230709s 52 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.9
++2.187304785s 54 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.13
++2.188466853s 93 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.5
++2.191599783s 73 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.44
++2.192792654s 30 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.11
++2.193726293s 38 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.3
++2.194156016s 10 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.54
++2.200000000s 1 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.12
++2.200000000s 2 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++2.200000000s 3 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.24
++2.200000000s 4 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++2.200000000s 5 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.17
++2.200000000s 6 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++2.200000000s 7 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++2.200000000s 8 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.15
++2.200000000s 9 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++2.200000000s 10 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.42
++2.200000000s 11 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.14
++2.200000000s 12 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++2.200000000s 13 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++2.200000000s 14 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.43
++2.200000000s 15 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.56
++2.200000000s 16 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++2.200000000s 17 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.47
++2.200000000s 18 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++2.200000000s 19 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++2.200000000s 20 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++2.200000000s 21 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.7
++2.200000000s 23 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.49
++2.200000000s 24 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.2
++2.200000000s 25 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.7
++2.200000000s 26 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.3
++2.200000000s 27 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.19
++2.200000000s 28 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.3
++2.200000000s 29 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.56
++2.200000000s 30 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.12
++2.200000000s 31 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.7
++2.200000000s 32 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.2
++2.200000000s 33 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++2.200000000s 34 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++2.200000000s 35 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.18
++2.200000000s 36 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++2.200000000s 37 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.4
++2.200000000s 38 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.14
++2.200000000s 39 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.28
++2.200000000s 40 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++2.200000000s 41 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.5
++2.200000000s 43 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++2.200000000s 44 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.41
++2.200000000s 45 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.7
++2.200000000s 46 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++2.200000000s 47 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.34
++2.200000000s 48 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++2.200000000s 49 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.23
++2.200000000s 50 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.54
++2.200000000s 51 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.2
++2.200000000s 52 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.19
++2.200000000s 53 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++2.200000000s 54 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.40
++2.200000000s 55 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.4
++2.200000000s 56 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.2
++2.200000000s 57 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.21
++2.200000000s 58 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.13
++2.200000000s 59 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++2.200000000s 60 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.6
++2.200000000s 61 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.12
++2.200000000s 62 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.13
++2.200000000s 63 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.40
++2.200000000s 64 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.16
++2.200000000s 65 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.16
++2.200000000s 66 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++2.200000000s 67 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++2.200000000s 68 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++2.200000000s 69 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.48
++2.200000000s 70 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.55
++2.200000000s 71 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.53
++2.200000000s 72 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.42
++2.200000000s 73 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.19
++2.200000000s 74 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++2.200000000s 75 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.19
++2.200000000s 76 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.20
++2.200000000s 77 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++2.200000000s 78 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.35
++2.200000000s 79 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.10
++2.200000000s 81 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.11
++2.200000000s 82 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.1
++2.200000000s 83 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++2.200000000s 84 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.15
++2.200000000s 85 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.12
++2.200000000s 86 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++2.200000000s 87 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.10
++2.200000000s 88 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.44
++2.200000000s 89 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.7
++2.200000000s 90 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.45
++2.200000000s 92 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.3
++2.200000000s 93 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.5
++2.200000000s 95 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.57
++2.200000000s 97 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.19
++2.200000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.13
++2.200000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++2.200000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.7
++2.200000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.20
++2.200000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.31
++2.200000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.28
++2.200000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.5
++2.200000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.40
++2.201423192s 32 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.6
++2.201773143s 33 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.42
++2.202390142s 42 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.8
++2.204435187s 49 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.6
++2.206696591s 65 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.9
++2.207600740s 73 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.18
++2.210500295s 72 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.12
++2.210651126s 4 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.57
++2.211398665s 52 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.51
++2.212160948s 92 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.11
++2.213186970s 7 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.1
++2.213582222s 3 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.30
++2.213743801s 54 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.40
++2.214145126s 87 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.16
++2.214215559s 34 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.52
++2.215250342s 43 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.36
++2.215765567s 21 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.3
++2.217055717s 59 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.8
++2.217120140s 45 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.21
++2.217132209s 29 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.56
++2.217290289s 9 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.41
++2.218026126s 83 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.9
++2.218510433s 25 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.7
++2.218997151s 87 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.9
++2.219407258s 6 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.54
++2.220407208s 11 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.47
++2.220415456s 39 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.3
++2.220624590s 62 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.32
++2.221098726s 51 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.6
++2.221756265s 74 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.12
++2.222808625s 23 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.49
++2.222986366s 30 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.12
++2.223721591s 50 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.54
++2.224947458s 33 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.13
++2.225003287s 39 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.28
++2.225554671s 30 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.37
++2.225710751s 78 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.7
++2.225808626s 3 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.7
++2.225864942s 17 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.14
++2.226291091s 7 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.37
++2.226370029s 42 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.19
++2.226756217s 26 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.3
++2.226997509s 16 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.28
++2.227765695s 29 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.3
++2.228641429s 52 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.16
++2.229118708s 25 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.18
++2.229210647s 82 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.9
++2.229313800s 2 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.18
++2.229571923s 38 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.14
++2.231157507s 63 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.40
++2.231736392s 75 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.19
++2.232798703s 38 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.13
++2.233181840s 61 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.12
++2.233258500s 71 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.53
++2.233374718s 6 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.7
++2.233953929s 34 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.8
++2.234033125s 21 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.2
++2.234210637s 71 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.1
++2.234461288s 78 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.35
++2.235124709s 48 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.29
++2.235183909s 41 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.20
++2.235579510s 76 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.28
++2.236514837s 15 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.52
++2.236613154s 8 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.7
++2.236972604s 47 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.34
++2.236974838s 28 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.1
++2.237525354s 50 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.17
++2.240128743s 25 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.4
++2.240756714s 30 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.1
++2.242171305s 46 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.15
++2.242240778s 16 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.9
++2.244645002s 36 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.16
++2.245141280s 51 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.2
++2.246032384s 14 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.33
++2.246445614s 24 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.14
++2.246775011s 62 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.41
++2.247486127s 44 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.41
++2.247603543s 41 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.53
++2.247921584s 72 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.42
++2.248537750s 21 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.53
++2.249253129s 34 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.39
++2.249828134s 83 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.1
++2.249885995s 75 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.49
++2.250067590s 7 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.6
++2.251653742s 75 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.20
++2.251674939s 57 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.56
++2.251786065s 49 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.23
++2.252533915s 7 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.3
++2.252671818s 51 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.26
++2.253716096s 1 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.29
++2.254150798s 69 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.48
++2.255458124s 56 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.25
++2.256622106s 12 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.2
++2.256849495s 63 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.15
++2.256928623s 35 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.21
++2.259996968s 9 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.43
++2.262297350s 39 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.20
++2.266217201s 73 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.19
++2.266779491s 70 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.3
++2.266779850s 79 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.4
++2.267716592s 24 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.29
++2.269997374s 70 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.55
++2.270251855s 20 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.3
++2.270328453s 1 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.12
++2.270889561s 20 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.42
++2.271192469s 63 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.22
++2.271917321s 64 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.50
++2.273133097s 84 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.7
++2.275909339s 63 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.9
++2.277397852s 7 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.9.0.1
++2.277672874s 45 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.27
++2.278452455s 9 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.7
++2.278817806s 3 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.7
++2.279129369s 76 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.6
++2.280611198s 69 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.11
++2.281228628s 70 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.47
++2.281628002s 6 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.29
++2.282780058s 5 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.7.0.2
++2.285118197s 19 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.2
++2.287416576s 35 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.11
++2.288699081s 29 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.3
++2.288802169s 36 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.17
++2.289411470s 19 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.20
++2.289463964s 59 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.7
++2.290501247s 50 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.16
++2.292262682s 84 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.4
++2.293299332s 19 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.10
++2.293596601s 40 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.2
++2.293678004s 18 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.3
++2.297920704s 33 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.8
++2.299321134s 41 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.51
++2.299476734s 13 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.16
++2.300000000s 1 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++2.300000000s 2 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.14
++2.300000000s 3 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++2.300000000s 4 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.56
++2.300000000s 5 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++2.300000000s 6 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.17
++2.300000000s 7 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.42
++2.300000000s 8 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.3
++2.300000000s 9 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.16
++2.300000000s 10 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.8
++2.300000000s 11 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.43
++2.300000000s 12 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.2
++2.300000000s 13 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.4
++2.300000000s 14 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.8
++2.300000000s 15 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.43
++2.300000000s 16 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.15
++2.300000000s 17 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++2.300000000s 18 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.9.0.1
++2.300000000s 19 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.18
++2.300000000s 21 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.26
++2.300000000s 23 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.2
++2.300000000s 24 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.33
++2.300000000s 25 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++2.300000000s 26 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.9.0.1
++2.300000000s 27 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++2.300000000s 28 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.37
++2.300000000s 29 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++2.300000000s 30 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++2.300000000s 32 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.35
++2.300000000s 33 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++2.300000000s 35 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.7
++2.300000000s 36 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.35
++2.300000000s 37 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.39
++2.300000000s 38 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.23
++2.300000000s 39 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.45
++2.300000000s 40 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.20
++2.300000000s 41 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.35
++2.300000000s 42 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.3
++2.300000000s 43 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++2.300000000s 44 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.51
++2.300000000s 46 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++2.300000000s 47 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.9
++2.300000000s 48 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.57
++2.300000000s 49 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++2.300000000s 50 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++2.300000000s 51 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.25
++2.300000000s 52 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.2
++2.300000000s 53 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++2.300000000s 54 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.54
++2.300000000s 55 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++2.300000000s 56 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.19
++2.300000000s 57 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++2.300000000s 58 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.15
++2.300000000s 59 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.55
++2.300000000s 60 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.46
++2.300000000s 61 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.8
++2.300000000s 62 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.11
++2.300000000s 63 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.12
++2.300000000s 64 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.17
++2.300000000s 65 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++2.300000000s 66 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++2.300000000s 67 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.15
++2.300000000s 68 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.4
++2.300000000s 69 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.3
++2.300000000s 70 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.26
++2.300000000s 71 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.37
++2.300000000s 72 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++2.300000000s 73 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.43
++2.300000000s 74 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.8
++2.300000000s 75 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++2.300000000s 76 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.47
++2.300000000s 77 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.18
++2.300000000s 78 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.51
++2.300000000s 79 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.9
++2.300000000s 81 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.33
++2.300000000s 82 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++2.300000000s 83 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.17
++2.300000000s 84 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.17
++2.300000000s 85 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.11
++2.300000000s 86 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.11
++2.300000000s 87 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++2.300000000s 88 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++2.300000000s 89 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.12
++2.300000000s 90 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.3
++2.300000000s 92 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.10
++2.300000000s 93 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++2.300000000s 95 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.56
++2.300000000s 97 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.5
++2.300000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.51
++2.300000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.51
++2.300000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.17
++2.300000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++2.300000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.10
++2.300000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.8
++2.300000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.19
++2.300000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.2
++2.301472185s 88 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.32
++2.304750269s 74 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.15
++2.304981238s 77 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.48
++2.305394707s 3 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.20
++2.305519183s 12 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.1
++2.308216756s 2 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.1
++2.309398486s 87 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.8
++2.309535073s 45 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.2
++2.309711775s 9 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.50
++2.309903703s 106 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.2
++2.311117634s 1 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.8
++2.311229541s 25 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.52
++2.313042854s 17 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.47
++2.314857348s 100 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.8
++2.316199847s 51 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.38
++2.316382357s 48 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.57
++2.316790914s 27 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.19
++2.316823644s 74 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.3
++2.318235855s 11 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.7.0.1
++2.319267504s 14 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.2
++2.319396529s 55 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.14
++2.319403710s 46 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.38
++2.320340887s 29 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.5
++2.320861522s 38 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.7
++2.322512350s 6 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.17
++2.322796197s 75 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.21
++2.322849976s 52 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.6
++2.323224795s 55 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.1
++2.324251401s 38 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.23
++2.324565287s 79 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.26
++2.324733170s 1 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.3
++2.324777715s 59 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.55
++2.325613789s 71 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.37
++2.325937762s 76 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.47
++2.326148101s 24 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.2
++2.326370029s 19 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.3.0.20
++2.327053204s 31 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.3
++2.327393150s 86 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.1
++2.327468259s 20 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.53
++2.327517946s 62 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.13
++2.328212485s 54 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.54
++2.328433813s 68 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.4
++2.328685765s 75 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.50
++2.328848354s 58 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.13
++2.328911526s 67 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.15
++2.329245841s 82 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.39
++2.329304947s 58 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.15
++2.329715411s 89 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.4
++2.329755092s 13 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.5
++2.329766017s 67 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.7
++2.330446293s 27 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.20
++2.330512705s 27 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.7
++2.330587107s 51 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.1
++2.330624784s 83 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.17
++2.330801086s 56 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.19
++2.331441514s 87 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.10
++2.331723324s 8 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.15
++2.332840526s 52 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.19
++2.332858879s 35 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.7
++2.333080253s 39 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.45
++2.333229296s 11 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.14
++2.333652804s 5 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.17
++2.333784146s 17 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.6
++2.334270269s 28 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.37
++2.334327594s 95 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.9
++2.334550217s 63 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.12
++2.334718816s 10 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.8
++2.334828613s 23 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.33
++2.334911532s 82 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.12
++2.335300685s 15 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.41
++2.335394959s 43 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.13
++2.335395254s 72 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.20
++2.336270270s 9 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.16
++2.336656030s 45 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.16
++2.336830382s 43 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.1
++2.337134125s 77 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.37
++2.337402913s 97 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.55
++2.337637844s 66 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.29
++2.337994047s 46 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.5
++2.338028295s 14 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.43
++2.338308411s 65 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.16
++2.338438236s 59 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.49
++2.338637332s 81 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.11
++2.338904649s 69 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.54
++2.339312622s 10 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.42
++2.340358386s 13 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.4
++2.341113342s 15 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.56
++2.341156140s 24 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.33
++2.341370783s 37 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.39
++2.341755652s 36 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.14
++2.342319329s 76 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.32
++2.342650229s 26 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.46
++2.342872898s 19 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.18
++2.342907635s 32 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.2
++2.343013572s 72 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.53
++2.343069595s 77 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.18
++2.343331100s 36 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.35
++2.343370345s 37 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.45
++2.343452721s 20 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.17
++2.343461786s 3 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.24
++2.343465342s 53 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.8
++2.343467154s 35 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.18
++2.343822633s 31 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.2
++2.343954656s 37 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.36
++2.344780140s 77 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.14
++2.344981656s 12 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.20
++2.345141833s 21 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.7
++2.345663605s 42 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.5
++2.345669554s 41 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.35
++2.346200800s 41 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.34
++2.346902566s 8 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.10
++2.347267886s 52 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.2
++2.347443804s 16 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.1
++2.348961290s 51 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.25
++2.349287158s 29 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.13
++2.349638501s 67 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.17
++2.350172451s 3 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.48
++2.351325419s 34 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.41
++2.351422573s 59 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.6
++2.352046514s 95 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.44
++2.353100506s 42 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.50
++2.353221387s 46 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.14
++2.353310077s 97 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.1
++2.354409534s 16 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.9
++2.355008935s 78 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.51
++2.356366674s 64 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.20
++2.356450775s 51 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.44
++2.356993431s 27 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.24
++2.358480079s 64 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.16
++2.359608655s 4 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.13
++2.360151390s 73 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.43
++2.361015654s 76 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.20
++2.361213419s 57 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.21
++2.361427630s 53 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.1
++2.361527437s 18 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.27
++2.361646277s 70 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.26
++2.361737607s 55 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.2
++2.361948486s 23 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.2
++2.362037180s 61 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.15
++2.364431584s 18 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.19
++2.364563207s 72 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.9
++2.364613218s 40 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.55
++2.364780596s 32 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.35
++2.364990272s 57 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.14
++2.365165023s 30 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.31
++2.368502017s 57 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.19
++2.369564294s 69 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.17
++2.370900800s 24 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.30
++2.372309087s 44 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.51
++2.373443766s 47 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.29
++2.375038369s 19 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.5
++2.377684103s 93 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.19
++2.377745252s 90 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.2
++2.378562223s 27 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.5
++2.382500676s 73 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.56
++2.387463636s 4 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.4
++2.388641027s 97 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.19
++2.389533787s 2 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.2
++2.389675803s 42 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.1.0.19
++2.390248902s 65 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.51
++2.391261268s 13 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.40
++2.392472151s 48 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.48
++2.393261401s 13 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.36
++2.394635567s 7 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.45
++2.394636475s 27 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.13
++2.395115887s 69 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.38
++2.396880135s 60 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.4
++2.397134930s 10 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.7
++2.397189649s 57 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.10
++2.399112138s 19 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.30
++2.399849073s 36 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.11
++2.399943468s 79 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.9
++2.400000000s 1 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.6
++2.400000000s 2 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.1
++2.400000000s 3 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.8
++2.400000000s 4 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.16
++2.400000000s 5 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.10
++2.400000000s 6 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.14
++2.400000000s 7 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.10
++2.400000000s 8 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.18
++2.400000000s 9 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.4
++2.400000000s 10 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++2.400000000s 11 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.49
++2.400000000s 12 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.5
++2.400000000s 13 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.39
++2.400000000s 14 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.1
++2.400000000s 15 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.10
++2.400000000s 16 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.47
++2.400000000s 17 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.5
++2.400000000s 18 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.9
++2.400000000s 19 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.8
++2.400000000s 20 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.32
++2.400000000s 21 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.30
++2.400000000s 23 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++2.400000000s 24 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.37
++2.400000000s 25 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.2
++2.400000000s 26 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.24
++2.400000000s 27 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++2.400000000s 28 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++2.400000000s 29 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.17
++2.400000000s 31 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++2.400000000s 32 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.39
++2.400000000s 33 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.18
++2.400000000s 34 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.55
++2.400000000s 36 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.37
++2.400000000s 37 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.7
++2.400000000s 38 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.12
++2.400000000s 39 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.4
++2.400000000s 40 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.2
++2.400000000s 41 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++2.400000000s 42 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.5
++2.400000000s 43 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.35
++2.400000000s 44 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.32
++2.400000000s 46 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.36
++2.400000000s 48 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.41
++2.400000000s 49 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.1
++2.400000000s 50 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.4
++2.400000000s 53 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.32
++2.400000000s 54 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.7
++2.400000000s 55 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++2.400000000s 56 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.19
++2.400000000s 58 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.57
++2.400000000s 59 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.19
++2.400000000s 62 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.1
++2.400000000s 63 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++2.400000000s 65 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.7
++2.400000000s 66 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.10
++2.400000000s 67 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++2.400000000s 68 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.5
++2.400000000s 69 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.28
++2.400000000s 70 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.28
++2.400000000s 72 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.2
++2.400000000s 74 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.10
++2.400000000s 75 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.17
++2.400000000s 76 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.15
++2.400000000s 77 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.31
++2.400000000s 79 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++2.400000000s 81 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.21
++2.400000000s 82 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.19
++2.400000000s 83 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++2.400000000s 84 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++2.400000000s 85 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.19
++2.400000000s 86 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++2.400000000s 87 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.6
++2.400000000s 88 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.43
++2.400000000s 89 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.5
++2.400000000s 90 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.2
++2.400000000s 92 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.11.0.1
++2.400000000s 93 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.31
++2.400000000s 95 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.10
++2.400000000s 97 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.23
++2.400000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.24
++2.400000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.49
++2.400000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.30
++2.400000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++2.400000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.24
++2.400000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.33
++2.400000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.6
++2.400446387s 60 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.3
++2.400459506s 39 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.5
++2.401370103s 58 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.38
++2.401898853s 85 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.17
++2.402045729s 37 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.8
++2.402182461s 54 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.8
++2.404329099s 69 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.28
++2.405242487s 23 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.21
++2.406494672s 50 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.47
++2.406902222s 83 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.5
++2.407410521s 65 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.14
++2.407425757s 16 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.43
++2.407783490s 68 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.1
++2.407949218s 11 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.1
++2.408465699s 73 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.22
++2.408990636s 64 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.10
++2.409206076s 88 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.44
++2.409535073s 45 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.7.0.2
++2.409698926s 29 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.4
++2.410192320s 62 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.11
++2.411442127s 45 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.7
++2.411682896s 78 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.15
++2.412230291s 14 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.14
++2.412261794s 4 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.56
++2.414250553s 23 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.8
++2.414695951s 2 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.10
++2.415141094s 58 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.57
++2.415178066s 46 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.3
++2.415199467s 18 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.13
++2.415454656s 54 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.7
++2.416111410s 95 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.7
++2.416379479s 86 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.20
++2.416778851s 14 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.55
++2.417456216s 42 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.12
++2.417700904s 29 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.21
++2.418773576s 93 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.20
++2.418933920s 47 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.9
++2.420021063s 56 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.2
++2.421059583s 41 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.52
++2.421114230s 84 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.15
++2.421169361s 81 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.16
++2.421367329s 30 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.1
++2.421453143s 40 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.1
++2.421458139s 2 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.14
++2.421469627s 89 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.7
++2.421753227s 36 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.37
++2.421830802s 27 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.8
++2.422008581s 33 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.20
++2.422706971s 79 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.36
++2.423180213s 29 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.32
++2.425066353s 38 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.12
++2.425152769s 17 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.50
++2.426443189s 24 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.37
++2.429435152s 14 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.24
++2.429501939s 11 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.43
++2.429685394s 37 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.7
++2.430072421s 44 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.32
++2.430708364s 34 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.55
++2.430805044s 55 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.5
++2.430844798s 18 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.9
++2.431565734s 74 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.19
++2.432212841s 1 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.1
++2.432413861s 8 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.3
++2.432643574s 59 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.14
++2.432737786s 30 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.5
++2.432855116s 49 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.38
++2.433537915s 61 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.8
++2.433729178s 48 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.41
++2.434270077s 86 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.30
++2.435914032s 3 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.20
++2.436305091s 32 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.2
++2.437058142s 30 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.14
++2.437087309s 46 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.36
++2.437250038s 75 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.17
++2.437352659s 34 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.16
++2.437615487s 53 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.32
++2.437684701s 16 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.42
++2.438317746s 5 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.6
++2.438388573s 65 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.1.0.14
++2.438679529s 82 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.1
++2.439680787s 59 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.2
++2.440073550s 90 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.19
++2.441090133s 92 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.6
++2.441510690s 20 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.54
++2.441821464s 43 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.35
++2.442092804s 1 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.31
++2.442101632s 1 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.6
++2.442292814s 49 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.18
++2.442309253s 64 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.17
++2.442443223s 76 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.15
++2.443406175s 7 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.10
++2.443846556s 3 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.8
++2.443860539s 61 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.2
++2.443994315s 28 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.50
++2.444520750s 29 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.15
++2.444565229s 26 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.9
++2.445106570s 54 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.22
++2.445713540s 26 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.24
++2.445719141s 16 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.15
++2.445753637s 12 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.2
++2.446002649s 21 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.26
++2.446200640s 27 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.33
++2.446250811s 9 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.18
++2.446255797s 15 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.43
++2.446508479s 77 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.12
++2.446899980s 88 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.11
++2.447868964s 57 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.7
++2.448460801s 8 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.18
++2.449895083s 9 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.57
++2.450547596s 63 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.26
++2.451187340s 77 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.31
++2.451482354s 89 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.9.0.1
++2.451934627s 70 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.28
++2.453171621s 7 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.42
++2.455634290s 58 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.24
++2.455851622s 39 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.53
++2.456103084s 77 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.11.0.1
++2.456395154s 54 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.31
++2.458333637s 43 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.29
++2.459136906s 32 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.39
++2.460584354s 8 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.3
++2.462300911s 40 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.20
++2.463147510s 6 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.1
++2.463667511s 37 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.54
++2.463972928s 63 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.27
++2.464187638s 93 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.23
++2.465117050s 10 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.7
++2.465277784s 33 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.40
++2.465975646s 72 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.6
++2.466672793s 49 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.14
++2.466749872s 43 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.3
++2.468565855s 46 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.4
++2.469205996s 78 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.4
++2.474309474s 60 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.29
++2.476810184s 53 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.55
++2.477145923s 18 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.8
++2.477702879s 90 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.7.0.2
++2.477899002s 50 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.48
++2.478383877s 9 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.25
++2.479113737s 60 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.24
++2.481815111s 36 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.2
++2.482824213s 19 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.11.0.1
++2.483007212s 42 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.11
++2.487247845s 77 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.5
++2.487715648s 72 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.17
++2.488711847s 61 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.10
++2.494280291s 65 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.11
++2.494469658s 74 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.38
++2.495143617s 8 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.39
++2.495990782s 49 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.41
++2.498336649s 23 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.1
++2.498551233s 74 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.8
++2.499498636s 33 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.1
++2.499741268s 69 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.3
++2.500000000s 2 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.12
++2.500000000s 3 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.28
++2.500000000s 4 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.17
++2.500000000s 5 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.37
++2.500000000s 7 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++2.500000000s 8 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.10
++2.500000000s 9 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++2.500000000s 10 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.21
++2.500000000s 11 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.42
++2.500000000s 12 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.8
++2.500000000s 13 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++2.500000000s 14 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.15
++2.500000000s 15 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.16
++2.500000000s 16 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.11
++2.500000000s 17 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.19
++2.500000000s 18 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.15
++2.500000000s 19 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.7
++2.500000000s 20 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.25
++2.500000000s 21 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.17
++2.500000000s 23 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++2.500000000s 24 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.4
++2.500000000s 25 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++2.500000000s 26 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.49
++2.500000000s 27 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++2.500000000s 28 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.15
++2.500000000s 29 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.23
++2.500000000s 30 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.22
++2.500000000s 31 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.4
++2.500000000s 32 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.47
++2.500000000s 34 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.35
++2.500000000s 35 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.12
++2.500000000s 36 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.23
++2.500000000s 37 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++2.500000000s 38 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++2.500000000s 39 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++2.500000000s 40 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.30
++2.500000000s 41 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++2.500000000s 42 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.18
++2.500000000s 43 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.41
++2.500000000s 44 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.49
++2.500000000s 45 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.8
++2.500000000s 46 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.34
++2.500000000s 47 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.49
++2.500000000s 48 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++2.500000000s 49 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.2
++2.500000000s 51 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.9
++2.500000000s 52 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.10
++2.500000000s 53 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++2.500000000s 54 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.5
++2.500000000s 55 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.15
++2.500000000s 56 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++2.500000000s 57 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.6
++2.500000000s 58 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.42
++2.500000000s 59 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.16
++2.500000000s 60 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.46
++2.500000000s 61 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++2.500000000s 62 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.8
++2.500000000s 64 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.53
++2.500000000s 65 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.8
++2.500000000s 66 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.4
++2.500000000s 67 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++2.500000000s 68 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.5
++2.500000000s 69 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.8
++2.500000000s 70 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.15
++2.500000000s 71 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.44
++2.500000000s 72 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.16
++2.500000000s 73 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.25
++2.500000000s 74 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++2.500000000s 75 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.34
++2.500000000s 76 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++2.500000000s 77 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.18
++2.500000000s 78 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.7
++2.500000000s 79 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++2.500000000s 81 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.35
++2.500000000s 82 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.7
++2.500000000s 83 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.7
++2.500000000s 84 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.18
++2.500000000s 85 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.45
++2.500000000s 86 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.13
++2.500000000s 87 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.4
++2.500000000s 88 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.18
++2.500000000s 90 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.30
++2.500000000s 92 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.10
++2.500000000s 93 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++2.500000000s 95 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++2.500000000s 97 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.11
++2.500000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.23
++2.500000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++2.500000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.53
++2.500000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++2.500000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.14
++2.500000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.48
++2.500000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.17
++2.500000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++2.502105676s 85 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.21
++2.503060971s 83 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.8
++2.503855609s 42 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.3
++2.504421801s 93 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.14
++2.505124501s 66 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.38
++2.505193395s 14 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.8
++2.506973352s 14 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.3.0.43
++2.507479541s 28 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.5
++2.509399994s 74 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.10
++2.510367210s 27 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.3
++2.511674885s 81 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.46
++2.512015829s 59 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.19
++2.512836854s 6 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.14
++2.513431660s 17 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.42
++2.513784574s 66 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.8
++2.513966551s 25 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.2
++2.515428798s 87 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.2
++2.517097586s 85 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.12
++2.517187682s 87 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.23
++2.517207177s 10 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.5
++2.517874214s 81 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.33
++2.518514083s 4 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.16
++2.518585435s 37 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.16
++2.518619642s 24 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.12
++2.518725234s 56 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.19
++2.519001980s 48 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.21
++2.519036724s 25 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.5
++2.519410666s 65 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.15
++2.519677517s 29 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.17
++2.520281422s 88 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.29
++2.520321080s 82 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.7
++2.520415456s 83 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.3.0.17
++2.520681499s 29 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.23
++2.521410057s 87 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.6
++2.521791000s 7 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.35
++2.523151482s 89 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.12
++2.524566346s 42 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.6
++2.525671124s 75 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.34
++2.525946261s 33 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.18
++2.526246830s 79 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.7
++2.526282152s 19 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.8
++2.526573229s 39 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.52
++2.526868924s 36 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.23
++2.528054121s 66 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.9.0.1
++2.528558225s 27 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.3
++2.528859750s 72 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.16
++2.529146134s 67 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.20
++2.529213680s 16 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.47
++2.529789773s 64 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.7
++2.529973236s 92 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.11.0.1
++2.530022066s 82 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.34
++2.530508981s 87 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.2
++2.530807102s 4 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.17
++2.531018331s 45 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.7
++2.531668977s 15 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.4
++2.532009749s 82 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.29
++2.532127544s 17 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.19
++2.532176812s 81 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.18
++2.532193844s 29 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.9
++2.533236534s 71 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.44
++2.534062340s 76 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.8
++2.534540734s 35 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.12
++2.535922276s 30 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.22
++2.537089858s 11 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.49
++2.537492945s 51 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.21
++2.538010479s 82 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.19
++2.538108367s 26 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.49
++2.538505357s 56 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.53
++2.538825530s 34 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.35
++2.539855376s 74 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.17
++2.539928367s 46 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.34
++2.540294196s 45 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.14
++2.540816854s 32 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.47
++2.540914190s 13 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.39
++2.542065885s 58 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.42
++2.542679581s 60 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.47
++2.542971190s 38 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.50
++2.543436065s 20 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.18
++2.543714758s 42 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.45
++2.543897885s 20 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.32
++2.544379508s 95 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.57
++2.544480348s 44 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.49
++2.544559980s 47 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.49
++2.545842249s 64 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.53
++2.547009313s 17 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.4
++2.548046333s 19 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.17
++2.549608969s 14 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.27
++2.549853655s 66 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.49
++2.550433585s 40 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.30
++2.550656536s 25 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.38
++2.551086105s 30 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.54
++2.551222831s 13 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.3
++2.551281943s 34 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.13
++2.552055377s 60 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.36
++2.552843492s 17 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.5
++2.552914180s 12 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.8
++2.553379773s 56 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.27
++2.553887494s 44 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.8
++2.556737294s 81 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.21
++2.557160887s 71 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.4
++2.558008123s 10 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.21
++2.558024424s 92 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.2
++2.558692548s 57 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.12
++2.559893293s 56 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.24
++2.560679894s 53 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.6
++2.561004754s 21 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.17
++2.561213419s 43 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.3.0.35
++2.561244670s 69 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.10
++2.561717736s 21 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.30
++2.563115884s 64 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.36
++2.564027420s 52 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.10
++2.564117410s 10 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.52
++2.564187638s 93 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.3.0.23
++2.566476856s 93 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.10
++2.566719747s 71 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.22
++2.566839749s 71 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.25
++2.567842557s 85 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.5
++2.567855254s 19 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.37
++2.568556250s 79 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.10
++2.568733060s 75 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.42
++2.569277381s 36 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.6
++2.571266229s 2 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.3
++2.572075437s 90 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.45
++2.572388719s 73 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.25
++2.574184961s 8 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.12
++2.575549360s 14 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.15
++2.575648880s 52 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.18
++2.575809823s 27 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.10
++2.576845321s 3 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.13
++2.577280838s 18 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.9.0.1
++2.577941514s 19 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.34
++2.578242632s 38 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.4
++2.578242946s 42 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.7.0.2
++2.579514068s 17 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.7
++2.580070370s 49 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.34
++2.581555024s 9 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.4
++2.582065674s 6 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.7
++2.582889506s 93 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.5
++2.587017165s 21 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.10
++2.587172622s 84 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.17
++2.588919302s 40 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.11
++2.589354275s 7 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.57
++2.589568571s 88 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.19
++2.590993006s 28 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.31
++2.591494797s 17 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.21
++2.591690963s 89 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.5
++2.593822573s 69 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.16
++2.594379373s 4 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.38
++2.596013785s 32 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.30
++2.596880135s 4 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.3.0.38
++2.597182565s 9 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.1
++2.597866086s 88 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.52
++2.598362652s 86 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.11
++2.599095039s 83 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.52
++2.599287554s 60 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.27
++2.599594102s 83 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.47
++2.599817336s 50 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.2
++2.600000000s 1 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.7
++2.600000000s 4 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.5
++2.600000000s 5 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.10
++2.600000000s 6 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.13
++2.600000000s 7 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++2.600000000s 8 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.53
++2.600000000s 9 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++2.600000000s 11 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.6
++2.600000000s 12 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.32
++2.600000000s 13 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.1
++2.600000000s 15 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++2.600000000s 17 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.9
++2.600000000s 18 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.10
++2.600000000s 20 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.8
++2.600000000s 21 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.9
++2.600000000s 23 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.9
++2.600000000s 26 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.3
++2.600000000s 27 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.23
++2.600000000s 28 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.53
++2.600000000s 29 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.47
++2.600000000s 30 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.39
++2.600000000s 32 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++2.600000000s 33 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.5
++2.600000000s 34 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.44
++2.600000000s 35 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.30
++2.600000000s 36 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++2.600000000s 37 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.57
++2.600000000s 38 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.4
++2.600000000s 39 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.24
++2.600000000s 40 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.48
++2.600000000s 41 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.10
++2.600000000s 42 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.48
++2.600000000s 43 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.55
++2.600000000s 44 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.53
++2.600000000s 45 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.21
++2.600000000s 46 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.45
++2.600000000s 47 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.2
++2.600000000s 48 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++2.600000000s 49 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.9
++2.600000000s 50 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.12
++2.600000000s 51 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.34
++2.600000000s 52 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.5
++2.600000000s 53 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.56
++2.600000000s 54 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++2.600000000s 55 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.15
++2.600000000s 56 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++2.600000000s 57 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.54
++2.600000000s 58 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.10
++2.600000000s 59 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.26
++2.600000000s 60 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.7
++2.600000000s 61 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.3
++2.600000000s 62 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.48
++2.600000000s 63 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.18
++2.600000000s 65 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.15
++2.600000000s 66 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.48
++2.600000000s 67 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++2.600000000s 68 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.9.0.1
++2.600000000s 69 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.40
++2.600000000s 70 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.45
++2.600000000s 71 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++2.600000000s 72 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.39
++2.600000000s 74 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.24
++2.600000000s 75 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.22
++2.600000000s 76 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.9
++2.600000000s 78 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++2.600000000s 79 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.12
++2.600000000s 81 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.20
++2.600000000s 82 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.3
++2.600000000s 83 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.26
++2.600000000s 84 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.19
++2.600000000s 85 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.9
++2.600000000s 86 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.2
++2.600000000s 87 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.18
++2.600000000s 88 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.57
++2.600000000s 89 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++2.600000000s 90 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.5
++2.600000000s 92 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.36
++2.600000000s 93 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++2.600000000s 95 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++2.600000000s 97 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.18
++2.600000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.18
++2.600000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.9
++2.600000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.40
++2.600000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.8
++2.600000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.14
++2.600000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.8
++2.600000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.44
++2.600000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.8
++2.600389791s 2 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.1
++2.602123983s 60 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.46
++2.604360245s 93 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.10
++2.605635962s 71 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.11
++2.606320669s 14 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.7.0.2
++2.606800364s 86 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.5
++2.606875401s 19 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.2
++2.608292193s 88 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.43
++2.608577684s 47 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.51
++2.609263207s 85 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.11
++2.611360375s 61 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.13
++2.611469078s 69 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.40
++2.613035292s 65 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.7
++2.613179933s 29 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.47
++2.613662226s 15 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.14
++2.615217863s 69 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.8
++2.615364485s 5 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.37
++2.615854171s 54 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.20
++2.616426618s 59 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.26
++2.616952569s 2 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.12
++2.616957792s 3 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.28
++2.617211122s 62 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.47
++2.619060252s 31 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.1
++2.619769428s 69 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.7
++2.620099444s 17 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.9
++2.620687304s 14 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.1
++2.621207790s 27 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.23
++2.622999138s 93 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.7
++2.623258993s 7 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.52
++2.623978508s 57 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.6
++2.624410833s 23 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.9
++2.624625038s 48 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.37
++2.624870402s 34 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.44
++2.625392339s 37 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.57
++2.626594376s 31 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.4
++2.626813987s 55 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.1
++2.629057903s 97 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.23
++2.630133186s 9 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.17
++2.630186864s 74 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.24
++2.630392582s 51 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.8
++2.630613337s 39 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.5.0.3
++2.631477273s 36 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.50
++2.631599549s 59 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.16
++2.631630282s 38 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.4
++2.631805233s 45 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.5
++2.632063634s 6 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.13
++2.632145462s 65 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.15
++2.632989900s 30 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.39
++2.634188629s 34 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.9
++2.634309046s 102 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.52
++2.635109505s 21 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.1
++2.635337835s 71 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.50
++2.636615144s 31 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.1
++2.636693888s 46 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.45
++2.636724504s 51 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.34
++2.636975237s 72 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.39
++2.637494015s 61 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.3
++2.637761269s 66 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.12
++2.637828278s 44 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.53
++2.637828278s 75 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.22
++2.638085180s 79 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.15
++2.639293040s 53 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.56
++2.639634784s 77 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.18
++2.639688278s 86 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.13
++2.640149551s 55 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.15
++2.640293669s 18 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.15
++2.640528277s 42 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.18
++2.641729626s 60 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.52
++2.641816216s 57 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.3.0.21
++2.641914980s 28 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.53
++2.642569013s 52 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.21
++2.642836701s 38 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.1
++2.643289161s 18 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.10
++2.644222620s 76 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.9
++2.645295775s 46 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.52
++2.645563760s 21 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.9
++2.645783103s 23 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.9
++2.645990176s 95 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.56
++2.646375280s 49 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.2
++2.646911448s 63 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.18
++2.647071070s 58 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.10
++2.647196647s 72 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.14
++2.647365631s 15 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.16
++2.647729259s 26 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.16
++2.648015070s 51 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.2
++2.648109113s 13 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.6
++2.648190938s 37 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.43
++2.648236775s 78 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.27
++2.649246725s 81 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.11
++2.649434782s 35 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.30
++2.649475574s 61 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.8
++2.649673607s 11 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.42
++2.649901504s 57 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.54
++2.651507281s 39 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.24
++2.652991309s 72 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.49
++2.654259886s 55 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.15
++2.655041975s 67 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.24
++2.655089030s 56 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.29
++2.655460408s 61 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.50
++2.656741023s 75 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.3.0.22
++2.656741315s 44 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.3.0.53
++2.656918347s 26 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.9.0.1
++2.656938106s 43 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.41
++2.657692650s 60 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.44
++2.658924890s 78 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.31
++2.659074606s 62 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.48
++2.660011593s 70 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.45
++2.660220225s 37 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.33
++2.662500196s 28 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.15
++2.662569357s 49 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.9
++2.662870332s 75 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.6
++2.662955222s 20 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.25
++2.664159412s 66 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.48
++2.664282263s 50 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.4
++2.664933286s 10 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.18
++2.666333920s 31 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.54
++2.666434483s 93 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.5.0.10
++2.667652018s 8 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.47
++2.668319049s 9 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.21
++2.670399252s 40 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.41
++2.670575480s 32 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.36
++2.670890867s 42 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.48
++2.672339253s 84 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.9
++2.672340855s 49 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.56
++2.673068383s 59 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.5
++2.674155267s 52 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.13
++2.674522768s 34 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.2
++2.674828547s 40 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.48
++2.674852779s 76 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.35
++2.675427008s 50 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.3
++2.675652636s 12 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.5
++2.675654060s 44 BNSMincastNode:HandlePeerClose(): [INFO ] Outgoing connection CLOSED: 10.3.0.53
++2.675654060s 75 BNSMincastNode:HandlePeerClose(): [INFO ] Outgoing connection CLOSED: 10.3.0.22
++2.677276412s 46 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.17
++2.680880080s 85 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.55
++2.684766594s 70 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.15
++2.684874379s 74 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.7
++2.685945027s 6 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.35
++2.687529324s 85 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.9
++2.688604291s 70 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.40
++2.688957520s 4 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.9
++2.690012149s 67 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.48
++2.693853242s 31 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.27
++2.693968382s 92 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.10
++2.696241697s 70 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.44
++2.696647988s 5 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.10
++2.697370896s 16 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.37
++2.698632629s 74 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.3
++2.699418275s 97 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.11
++2.700000000s 1 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.18
++2.700000000s 2 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.9
++2.700000000s 3 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.14
++2.700000000s 4 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.13
++2.700000000s 5 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.10
++2.700000000s 6 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.8
++2.700000000s 7 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.10
++2.700000000s 9 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.9.0.1
++2.700000000s 10 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.12
++2.700000000s 11 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.9
++2.700000000s 12 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.6
++2.700000000s 13 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.51
++2.700000000s 14 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.11
++2.700000000s 16 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.31
++2.700000000s 17 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.31
++2.700000000s 18 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.55
++2.700000000s 19 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.5
++2.700000000s 20 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.10
++2.700000000s 21 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.3
++2.700000000s 23 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.11
++2.700000000s 24 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++2.700000000s 25 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.31
++2.700000000s 26 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.4
++2.700000000s 27 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.55
++2.700000000s 28 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.10
++2.700000000s 29 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.8
++2.700000000s 30 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.43
++2.700000000s 31 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.15
++2.700000000s 32 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.41
++2.700000000s 33 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.2
++2.700000000s 34 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.54
++2.700000000s 35 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++2.700000000s 36 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.12
++2.700000000s 37 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++2.700000000s 38 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++2.700000000s 39 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.41
++2.700000000s 40 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++2.700000000s 41 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.7
++2.700000000s 42 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.6
++2.700000000s 43 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.2
++2.700000000s 44 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.7
++2.700000000s 45 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.2
++2.700000000s 46 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.22
++2.700000000s 47 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.20
++2.700000000s 48 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.9
++2.700000000s 49 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++2.700000000s 50 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++2.700000000s 51 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.19
++2.700000000s 52 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++2.700000000s 53 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.13
++2.700000000s 54 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.17
++2.700000000s 55 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.13
++2.700000000s 56 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++2.700000000s 57 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.47
++2.700000000s 58 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.35
++2.700000000s 59 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.57
++2.700000000s 61 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.53
++2.700000000s 62 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.42
++2.700000000s 63 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++2.700000000s 64 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.26
++2.700000000s 65 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++2.700000000s 66 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.1
++2.700000000s 67 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.44
++2.700000000s 68 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.1
++2.700000000s 70 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.41
++2.700000000s 71 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++2.700000000s 72 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.45
++2.700000000s 73 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++2.700000000s 75 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.40
++2.700000000s 76 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.16
++2.700000000s 77 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.4
++2.700000000s 78 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.25
++2.700000000s 79 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.7
++2.700000000s 82 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++2.700000000s 83 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.4
++2.700000000s 84 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.30
++2.700000000s 85 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.21
++2.700000000s 86 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.8
++2.700000000s 87 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.1
++2.700000000s 88 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.30
++2.700000000s 89 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.21
++2.700000000s 90 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.48
++2.700000000s 93 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.32
++2.700000000s 95 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++2.700000000s 97 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.34
++2.700000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.4
++2.700000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.11.0.1
++2.700000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.8
++2.700000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.30
++2.700000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++2.700000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.5
++2.700000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.11.0.1
++2.700000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.6
++2.700129165s 74 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.1
++2.700208298s 92 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.2
++2.701898853s 17 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.5.0.5
++2.704291602s 86 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.8
++2.706259720s 3 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.39
++2.706342061s 70 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.20
++2.706459114s 88 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.6
++2.707741372s 84 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.18
++2.707892837s 78 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.7
++2.707894302s 67 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.2
++2.708120373s 93 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.1
++2.708292193s 65 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.8
++2.709456909s 18 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.55
++2.709528678s 13 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.6
++2.710202348s 27 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.6
++2.710444781s 37 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.18
++2.710792487s 18 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.20
++2.711272747s 59 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.57
++2.712242654s 70 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.18
++2.712439967s 65 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.5.0.8
++2.714516364s 1 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.16
++2.715220706s 65 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.1
++2.715692641s 2 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.9
++2.715831984s 9 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.1
++2.715927646s 95 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.18
++2.716555598s 79 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.9.0.1
++2.716888392s 79 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.37
++2.717097586s 12 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.5.0.5
++2.719543695s 87 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.43
++2.719875211s 88 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.18
++2.719875252s 2 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.27
++2.720719532s 38 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.15
++2.720830438s 15 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.10
++2.721499658s 75 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.40
++2.722414679s 67 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.44
++2.722799326s 23 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.43
++2.723146128s 9 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.2
++2.723764579s 30 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.43
++2.723765122s 56 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.8
++2.724515980s 72 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.45
++2.724535288s 64 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.11
++2.724739136s 81 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.35
++2.725206765s 41 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.10
++2.725248443s 8 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.53
++2.726025416s 50 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.12
++2.726576790s 40 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.52
++2.727936922s 16 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.11
++2.728269237s 56 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.3
++2.728588851s 81 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.9
++2.729494181s 54 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.17
++2.729552800s 27 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.55
++2.730509012s 57 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.47
++2.730516310s 12 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.32
++2.730583195s 79 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.12
++2.730737583s 39 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.4
++2.730829001s 93 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.31
++2.731372490s 92 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.14
++2.731378161s 15 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.33
++2.731400701s 48 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.7
++2.731558886s 45 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.2
++2.731829606s 78 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.25
++2.732257342s 62 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.53
++2.732479569s 5 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.10
++2.733394653s 63 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.5
++2.733621183s 66 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.45
++2.734254280s 34 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.54
++2.734895902s 61 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.53
++2.734906859s 54 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.1
++2.735368723s 63 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.21
++2.735640931s 30 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.34
++2.735677490s 65 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.8
++2.735918924s 51 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.9
++2.736763228s 58 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.35
++2.736785052s 67 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.50
++2.737501348s 11 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.6
++2.739266799s 1 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.7
++2.739838720s 74 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.18
++2.740671264s 25 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.31
++2.740735477s 62 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.42
++2.741335589s 31 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.15
++2.742789772s 51 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.19
++2.743307148s 64 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.26
++2.743323036s 55 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.13
++2.743591077s 45 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.11.0.1
++2.743745090s 15 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.6
++2.744218870s 39 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.32
++2.744317240s 77 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.5
++2.744440459s 47 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.20
++2.745183499s 87 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.18
++2.745762916s 69 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.35
++2.746008736s 45 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.21
++2.746907887s 39 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.41
++2.747250200s 5 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.10
++2.747342764s 24 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.23
++2.747545194s 33 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.6
++2.747727835s 47 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.56
++2.748721469s 10 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.5
++2.749605222s 93 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.28
++2.750123164s 27 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.41
++2.751438852s 74 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.4
++2.751463657s 89 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.3
++2.751837432s 76 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.12
++2.752085521s 46 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.22
++2.752353637s 75 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.39
++2.752831213s 90 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.57
++2.753096253s 43 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.55
++2.753157400s 43 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.5
++2.753176608s 68 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.38
++2.753310077s 92 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.11.0.1
++2.755136773s 57 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.36
++2.755391190s 15 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.1
++2.756038239s 49 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.1
++2.758110729s 67 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.10
++2.758275354s 20 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.8
++2.759853286s 81 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.20
++2.760505283s 32 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.41
++2.761024568s 49 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.20
++2.761031279s 53 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.3
++2.761115751s 64 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.40
++2.761644451s 7 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.27
++2.761796549s 24 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.27
++2.762004925s 37 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.9
++2.763166574s 73 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.50
++2.763889184s 11 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.5
++2.764187216s 41 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.29
++2.764938843s 48 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.42
++2.764974002s 35 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.33
++2.765875074s 1 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.18
++2.766903720s 32 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.1
++2.770344166s 63 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.17
++2.773758641s 81 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.9
++2.773839227s 70 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.41
++2.774421898s 85 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.7.0.2
++2.776223256s 66 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.10
++2.776309484s 95 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.10
++2.776507048s 66 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.4
++2.777141126s 15 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.48
++2.778129251s 44 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.24
++2.783726692s 90 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.2
++2.784010484s 24 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.4
++2.786561811s 85 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.19
++2.787808405s 10 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.19
++2.789043431s 12 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.28
++2.790742156s 63 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.10
++2.791531246s 42 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.27
++2.791690963s 85 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.5.0.9
++2.792328907s 75 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.8
++2.792411598s 3 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.34
++2.792693401s 49 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.2
++2.793583124s 84 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.19
++2.794731163s 72 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.51
++2.795760528s 54 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.12
++2.795879975s 12 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.57
++2.796128256s 60 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.1.0.4
++2.796417047s 84 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.28
++2.797078194s 7 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.26
++2.797457495s 79 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.38
++2.798828455s 18 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.1
++2.798887235s 8 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.10
++2.799132506s 11 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.11.0.1
++2.800000000s 1 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.24
++2.800000000s 2 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.9
++2.800000000s 3 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++2.800000000s 4 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.7
++2.800000000s 5 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.2
++2.800000000s 6 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.46
++2.800000000s 7 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.2
++2.800000000s 8 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.51
++2.800000000s 9 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.26
++2.800000000s 10 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.1
++2.800000000s 11 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.12
++2.800000000s 12 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.5
++2.800000000s 14 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.16
++2.800000000s 16 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.56
++2.800000000s 17 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.8
++2.800000000s 18 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.31
++2.800000000s 21 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.9
++2.800000000s 23 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.16
++2.800000000s 24 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.8
++2.800000000s 25 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++2.800000000s 26 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.6
++2.800000000s 27 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++2.800000000s 28 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.7
++2.800000000s 29 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.10
++2.800000000s 30 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.4
++2.800000000s 31 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.22
++2.800000000s 33 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.1
++2.800000000s 34 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.6
++2.800000000s 35 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.8
++2.800000000s 36 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.6
++2.800000000s 37 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.2
++2.800000000s 38 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.36
++2.800000000s 39 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.48
++2.800000000s 42 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.4
++2.800000000s 43 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.28
++2.800000000s 45 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.28
++2.800000000s 47 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.4
++2.800000000s 48 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.17
++2.800000000s 49 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++2.800000000s 52 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.6
++2.800000000s 53 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.19
++2.800000000s 55 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.23
++2.800000000s 57 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++2.800000000s 59 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.48
++2.800000000s 60 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.40
++2.800000000s 61 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.19
++2.800000000s 62 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.1
++2.800000000s 63 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++2.800000000s 64 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++2.800000000s 65 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++2.800000000s 66 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.40
++2.800000000s 67 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.3
++2.800000000s 68 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.40
++2.800000000s 71 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.23
++2.800000000s 72 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.57
++2.800000000s 73 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++2.800000000s 74 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.11.0.1
++2.800000000s 75 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++2.800000000s 76 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.45
++2.800000000s 78 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++2.800000000s 79 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.13
++2.800000000s 81 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++2.800000000s 82 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.13
++2.800000000s 83 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.20
++2.800000000s 84 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++2.800000000s 85 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.7
++2.800000000s 86 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++2.800000000s 87 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++2.800000000s 88 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.8
++2.800000000s 89 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.39
++2.800000000s 90 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.44
++2.800000000s 92 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.16
++2.800000000s 95 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.14
++2.800000000s 97 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++2.800000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.10
++2.800000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.32
++2.800000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.4
++2.800000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.35
++2.800000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.1
++2.800000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.46
++2.800000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.49
++2.800000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.5
++2.800212831s 81 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.52
++2.801539070s 88 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.57
++2.801614212s 23 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.2
++2.802123983s 60 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.3.0.46
++2.802338703s 1 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.32
++2.802611366s 48 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.38
++2.804849217s 23 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.11
++2.805097339s 48 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.9
++2.806251176s 86 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.11
++2.807236747s 83 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.26
++2.808916146s 29 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.1
++2.809194461s 27 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.2
++2.810276429s 41 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.38
++2.810717814s 63 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.48
++2.811611235s 18 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.4
++2.811621348s 37 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.38
++2.811701858s 33 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.5
++2.811830665s 45 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.28
++2.811845579s 87 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.56
++2.812244908s 1 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.7.0.2
++2.812428119s 88 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.3.0.43
++2.816156555s 75 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.1
++2.816256289s 82 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.3
++2.816330540s 23 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.16
++2.816575893s 88 BNSMincastNode:HandlePeerClose(): [INFO ] Outgoing connection CLOSED: 10.3.0.43
++2.816666958s 6 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.8
++2.817746619s 18 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.7
++2.817750737s 50 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.23
++2.818362741s 10 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.12
++2.818477174s 68 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.40
++2.818981744s 78 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.9.0.1
++2.819022682s 21 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.23
++2.820853788s 32 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.5
++2.820996793s 72 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.57
++2.821477692s 66 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.40
++2.822607461s 78 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.50
++2.823004051s 38 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.36
++2.824156094s 77 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.4
++2.824163832s 38 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.1
++2.824233468s 23 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.53
++2.825587470s 63 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.52
++2.827195220s 3 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.9
++2.827723221s 62 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.46
++2.827988464s 4 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.13
++2.828565824s 79 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.13
++2.829632147s 77 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.21
++2.829790239s 40 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.8
++2.830729486s 71 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.23
++2.831069397s 5 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.2
++2.831145656s 55 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.23
++2.831508408s 79 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.50
++2.831798557s 76 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.45
++2.831996051s 3 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.14
++2.832224191s 62 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.44
++2.832380070s 65 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.20
++2.832959730s 25 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.29
++2.833088361s 81 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.15
++2.833881314s 72 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.56
++2.834791263s 58 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.16
++2.835381850s 95 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.4
++2.835392374s 64 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.1
++2.835856613s 71 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.3
++2.837103865s 57 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.1
++2.837442627s 88 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.20
++2.838388583s 74 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.41
++2.838692066s 11 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.9
++2.839138129s 38 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.14
++2.839634784s 18 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.3.0.55
++2.839764927s 20 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.1
++2.841063675s 36 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.12
++2.841838348s 17 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.31
++2.841908696s 33 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.16
++2.842234086s 97 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.18
++2.842476578s 49 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.7
++2.842757777s 47 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.4
++2.842842830s 35 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.57
++2.842942834s 17 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.8
++2.844975124s 90 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.5
++2.845335727s 12 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.6
++2.846082556s 31 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.22
++2.846088858s 45 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.49
++2.846706266s 45 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.33
++2.846921383s 2 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.5
++2.847115788s 52 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.7
++2.847696470s 67 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.54
++2.848535351s 42 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.43
++2.848606172s 76 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.16
++2.849436656s 51 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.3
++2.850353907s 1 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.10
++2.850674933s 12 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.5
++2.851389632s 53 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.13
++2.851445453s 27 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.27
++2.851592972s 57 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.29
++2.852409077s 49 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.8
++2.852570594s 92 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.10
++2.852850521s 85 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.1.0.17
++2.853058270s 23 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.42
++2.853887824s 89 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.29
++2.856536667s 59 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.48
++2.856627701s 8 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.17
++2.857271996s 33 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.1
++2.857619002s 9 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.26
++2.858009174s 16 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.31
++2.861723058s 93 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.45
++2.862504423s 104 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.5
++2.862955222s 47 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.1.0.20
++2.864137117s 26 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.25
++2.867105527s 13 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.51
++2.867601974s 14 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.16
++2.869121160s 44 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.9
++2.874824986s 39 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.48
++2.875039549s 88 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.6
++2.875635168s 85 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.1.0.12
++2.875993328s 5 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.12
++2.877012078s 34 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.10
++2.877167225s 49 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.5
++2.877262064s 85 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.45
++2.877384624s 51 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.35
++2.878605427s 30 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.27
++2.881246595s 90 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.15
++2.884785845s 70 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.37
++2.885309310s 4 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.55
++2.887540785s 89 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.5.0.5
++2.889425208s 90 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.30
++2.890230218s 19 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.4
++2.890950545s 90 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.7.0.1
++2.892781312s 35 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.4
++2.896352002s 53 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.7.0.2
++2.897545710s 4 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.5
++2.897986209s 36 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.3
++2.900000000s 2 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++2.900000000s 3 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.22
++2.900000000s 6 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.16
++2.900000000s 7 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.21
++2.900000000s 8 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++2.900000000s 9 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.9.0.1
++2.900000000s 13 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++2.900000000s 14 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++2.900000000s 15 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.2
++2.900000000s 16 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.14
++2.900000000s 19 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++2.900000000s 20 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.10
++2.900000000s 21 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.36
++2.900000000s 24 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.18
++2.900000000s 28 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.14
++2.900000000s 29 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.40
++2.900000000s 30 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++2.900000000s 31 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.32
++2.900000000s 33 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.39
++2.900000000s 34 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.36
++2.900000000s 35 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.25
++2.900000000s 37 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.4
++2.900000000s 40 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.10
++2.900000000s 41 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.2
++2.900000000s 42 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.1
++2.900000000s 43 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.57
++2.900000000s 44 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++2.900000000s 45 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.41
++2.900000000s 48 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.11
++2.900000000s 50 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.41
++2.900000000s 54 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.7
++2.900000000s 60 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++2.900000000s 61 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++2.900000000s 62 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++2.900000000s 64 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.44
++2.900000000s 65 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.8
++2.900000000s 68 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.57
++2.900000000s 69 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.23
++2.900000000s 73 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.9
++2.900000000s 74 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.9.0.1
++2.900000000s 77 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.1
++2.900000000s 81 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.41
++2.900000000s 82 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.8
++2.900000000s 83 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.5
++2.900000000s 84 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.45
++2.900000000s 85 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.6
++2.900000000s 86 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.15
++2.900000000s 87 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.2
++2.900000000s 88 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.16
++2.900000000s 89 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.25
++2.900000000s 90 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++2.900000000s 92 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++2.900000000s 95 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.8
++2.900000000s 97 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++2.900000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++2.900000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.49
++2.900000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.45
++2.900000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++2.900000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.47
++2.900000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.53
++2.900000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++2.900000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.3
++2.900976682s 67 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.38
++2.901739109s 16 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.14
++2.902286051s 79 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.8
++2.903792078s 3 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.49
++2.905097339s 9 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.3.0.26
++2.906282169s 79 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.7
++2.907022862s 6 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.46
++2.907359293s 33 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.2
++2.908040469s 31 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.11
++2.908331284s 34 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.6
++2.908592125s 14 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.16
++2.909442829s 77 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.1.0.18
++2.910158085s 93 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.8
++2.910506494s 82 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.1
++2.910875756s 48 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.3
++2.911599077s 12 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.14
++2.912259310s 70 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.17
++2.912780625s 53 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.17
++2.914046836s 69 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.23
++2.914621715s 83 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.4
++2.914756467s 84 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.44
++2.914895213s 26 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.6
++2.915894974s 68 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.57
++2.916323697s 106 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.3
++2.916575893s 65 BNSMincastNode:HandlePeerClose(): [INFO ] Outgoing connection CLOSED: 10.5.0.8
++2.916680886s 29 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.10
++2.917544324s 5 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.11
++2.917988919s 86 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.12
++2.918103741s 29 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.40
++2.919101103s 41 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.7
++2.920454340s 35 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.1
++2.920538333s 48 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.17
++2.920658183s 7 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.30
++2.921064901s 45 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.47
++2.921116004s 34 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.36
++2.922408028s 88 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.30
++2.922902330s 16 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.54
++2.923843274s 79 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.46
++2.924017528s 50 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.41
++2.924385982s 25 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.2
++2.924487121s 101 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.8
++2.924553226s 92 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.36
++2.925049587s 42 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.4
++2.925192989s 44 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.7
++2.926009906s 84 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.2
++2.927053174s 13 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.31
++2.927104851s 31 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.32
++2.927164552s 62 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.7
++2.927298541s 3 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.8
++2.927656806s 14 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.11
++2.927950012s 61 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.19
++2.928723726s 11 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.12
++2.929947647s 97 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.7.0.1
++2.930651611s 97 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.34
++2.931870055s 88 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.8
++2.932131705s 58 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.12
++2.933165956s 16 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.56
++2.933735265s 45 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.41
++2.934055033s 92 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.27
++2.935033506s 43 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.28
++2.935987133s 63 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.28
++2.937038904s 53 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.16
++2.938425454s 53 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.19
++2.938683176s 6 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.16
++2.940653650s 54 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.9
++2.940925745s 2 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.9
++2.940999362s 86 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.7
++2.941417272s 7 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.2
++2.943728645s 35 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.8
++2.943753674s 103 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.6
++2.944421026s 20 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.3.0.25
++2.944706488s 28 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.14
++2.945820283s 64 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.44
++2.946189774s 60 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.57
++2.947556276s 35 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.25
++2.949045996s 68 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.9.0.1
++2.950328855s 87 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.14
++2.950569549s 63 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.23
++2.950663914s 73 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.13
++2.951094490s 9 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.9.0.1
++2.952301448s 93 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.1
++2.952583702s 18 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.31
++2.952787889s 90 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.8
++2.953176608s 68 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.3.0.38
++2.953913693s 60 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.26
++2.955069051s 84 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.38
++2.956919959s 1 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.24
++2.957562257s 14 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.3
++2.957663676s 48 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.1.0.9
++2.958037187s 16 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.6
++2.958777969s 95 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.20
++2.958819160s 83 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.20
++2.960552198s 68 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.6
++2.961124115s 20 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.10
++2.961494603s 40 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.10
++2.962929680s 6 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.12
++2.963361539s 40 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.11.0.1
++2.963671905s 93 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.5
++2.964334089s 90 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.44
++2.964424107s 32 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.9.0.1
++2.964681004s 13 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.1
++2.965420621s 60 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.19
++2.967062167s 36 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.6
++2.967433586s 60 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.15
++2.968272707s 8 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.51
++2.968700720s 66 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.42
++2.969378614s 106 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.5
++2.970796864s 21 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.9
++2.971334286s 47 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.13
++2.972318234s 6 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.4
++2.975020795s 10 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.7
++2.975589609s 24 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.10
++2.976682498s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.1
++2.979840177s 41 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.5
++2.980794750s 17 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.26
++2.986644888s 4 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.20
++2.986693551s 3 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.14
++2.989709000s 84 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.30
++2.990929790s 30 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.3
++2.991693951s 10 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.20
++2.991789636s 19 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.39
++2.992213710s 32 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.18
++2.992556730s 34 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.11
++2.992606894s 8 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.8
++2.992899716s 50 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.38
++2.997002435s 1 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.13
++2.999763896s 78 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.16
++3.000000000s 4 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++3.000000000s 10 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.4
++3.000000000s 13 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.9.0.1
++3.000000000s 14 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.9.0.1
++3.000000000s 15 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.26
++3.000000000s 18 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.1
++3.000000000s 19 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.6
++3.000000000s 20 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++3.000000000s 21 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.6
++3.000000000s 24 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.42
++3.000000000s 26 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++3.000000000s 28 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.19
++3.000000000s 29 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.2
++3.000000000s 30 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.9.0.1
++3.000000000s 31 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++3.000000000s 33 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.6
++3.000000000s 37 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.48
++3.000000000s 41 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.16
++3.000000000s 42 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.3
++3.000000000s 43 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.20
++3.000000000s 44 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.2
++3.000000000s 47 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.28
++3.000000000s 51 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++3.000000000s 52 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++3.000000000s 60 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.8
++3.000000000s 61 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.11.0.1
++3.000000000s 62 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++3.000000000s 65 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.9.0.1
++3.000000000s 68 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.4
++3.000000000s 69 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.5
++3.000000000s 73 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.9
++3.000000000s 74 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.4
++3.000000000s 77 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++3.000000000s 81 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++3.000000000s 83 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.34
++3.000000000s 85 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.36
++3.000000000s 87 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.54
++3.000000000s 89 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.4
++3.000000000s 90 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.26
++3.000000000s 92 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.6
++3.000000000s 93 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.1
++3.000000000s 95 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.1
++3.000000000s 97 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.49
++3.000000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.13
++3.000000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.43
++3.000000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.18
++3.000000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.7
++3.000000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.18
++3.000000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.2
++3.000000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.6
++3.000000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.49
++3.002549911s 50 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.21
++3.004308230s 93 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.32
++3.006004267s 8 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.13
++3.007465606s 19 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.31
++3.007574594s 7 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.10
++3.008983731s 19 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.52
++3.009441810s 87 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.57
++3.011019169s 89 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.2
++3.011351218s 2 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.11
++3.011487155s 7 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.6
++3.012136384s 24 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.7
++3.012461498s 36 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.6
++3.015764612s 23 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.2
++3.018538968s 37 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.2
++3.020779488s 74 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.4
++3.020910108s 74 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.11.0.1
++3.020967420s 92 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.16
++3.021946065s 26 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.3
++3.023588564s 33 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.39
++3.025068561s 14 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.7
++3.025292534s 20 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.10
++3.025376120s 2 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.20
++3.025661159s 47 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.28
++3.026114524s 81 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.6
++3.026983001s 51 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.52
++3.027363169s 85 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.21
++3.027902687s 48 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.11
++3.028307624s 66 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.1
++3.028672657s 87 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.19
++3.028829030s 62 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.7
++3.028829209s 32 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.7.0.1
++3.028898250s 53 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.18
++3.029279691s 28 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.7
++3.029336541s 52 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.1
++3.030031342s 87 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.2
++3.030604735s 82 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.13
++3.030683199s 81 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.13
++3.030691983s 29 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.2
++3.031188175s 26 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.52
++3.031910377s 41 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.16
++3.032029800s 30 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.7
++3.033155016s 89 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.39
++3.033589730s 52 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.8
++3.035395131s 46 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.1
++3.037810602s 87 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.22
++3.038229974s 20 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.3
++3.038493659s 50 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.25
++3.039591285s 43 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.57
++3.040426391s 3 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.22
++3.040454587s 74 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.29
++3.041300258s 24 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.18
++3.041570197s 31 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.20
++3.041618605s 95 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.1
++3.041630196s 43 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.2
++3.041827551s 33 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.14
++3.042035768s 16 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.14
++3.042225274s 61 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.7
++3.042640297s 97 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.29
++3.043598382s 82 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.8
++3.044001349s 23 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.30
++3.044761386s 21 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.36
++3.045539371s 89 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.21
++3.045985313s 56 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.11.0.1
++3.046040129s 24 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.7
++3.046931093s 85 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.4
++3.047534997s 38 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.19
++3.051471066s 60 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.45
++3.052957092s 8 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.27
++3.053323719s 24 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.42
++3.053884564s 44 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.1
++3.054071247s 103 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.8
++3.054673116s 15 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.2
++3.056192090s 89 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.21
++3.060131075s 77 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.27
++3.061330829s 73 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.8
++3.062349338s 42 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.9
++3.063577224s 74 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.19
++3.065023030s 99 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++3.065317127s 30 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.7.0.2
++3.065852205s 84 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.52
++3.065890673s 67 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.5
++3.070656259s 37 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.48
++3.074623012s 30 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.4
++3.076657580s 95 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.9
++3.080006596s 64 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.2
++3.084137764s 52 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.10
++3.085367114s 61 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.11
++3.086788128s 89 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.4
++3.086829659s 58 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.7.0.1
++3.087684511s 42 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.2
++3.090204748s 49 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.55
++3.091553772s 28 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.10
++3.091840442s 11 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.26
++3.093219745s 7 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.40
++3.095334844s 2 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.7
++3.098036481s 7 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.8
++3.098185030s 97 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.3
++3.100000000s 4 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.28
++3.100000000s 10 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.43
++3.100000000s 13 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.9.0.1
++3.100000000s 14 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++3.100000000s 18 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.9
++3.100000000s 19 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.23
++3.100000000s 26 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.55
++3.100000000s 42 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.56
++3.100000000s 45 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.8
++3.100000000s 60 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.2
++3.100000000s 62 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.3
++3.100000000s 64 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.25
++3.100000000s 65 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.46
++3.100000000s 68 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++3.100000000s 69 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.11.0.1
++3.100000000s 73 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.53
++3.100000000s 78 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.48
++3.100000000s 83 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.56
++3.100000000s 85 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.22
++3.100000000s 92 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.8
++3.100000000s 95 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++3.100000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.47
++3.100000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.7
++3.100000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.47
++3.100000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.9
++3.100000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++3.100000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.10
++3.100000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.20
++3.100039695s 60 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.40
++3.105982633s 70 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.15
++3.106215284s 54 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.7
++3.107663289s 4 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.52
++3.109386414s 79 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.21
++3.109402027s 88 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.16
++3.110229382s 8 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.2
++3.110627431s 44 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.3
++3.111945562s 18 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.2
++3.113060448s 36 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.16
++3.113335681s 7 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.39
++3.113820170s 90 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.48
++3.116144871s 86 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.15
++3.117134293s 58 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.21
++3.118685271s 86 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.14
++3.120463823s 81 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.41
++3.122648097s 65 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.46
++3.123573824s 95 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.46
++3.126086331s 41 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.2
++3.126724100s 19 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.6
++3.127237615s 42 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.56
++3.129888479s 44 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.2
++3.130170497s 84 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.9
++3.130608517s 95 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.38
++3.130804220s 1 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.22
++3.131368167s 97 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.52
++3.131443204s 16 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.7.0.1
++3.132012274s 24 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.15
++3.133893762s 49 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.8
++3.133940768s 68 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.43
++3.134567035s 52 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.4
++3.134969090s 28 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.19
++3.136167024s 89 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.25
++3.137272293s 26 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.55
++3.138147696s 42 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.9.0.1
++3.139168325s 28 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.1
++3.139353230s 60 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.28
++3.139627276s 73 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.38
++3.140870754s 78 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.20
++3.142113249s 73 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.9
++3.143939911s 87 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.6
++3.144656545s 15 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.26
++3.145910001s 35 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.2
++3.149710274s 61 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.9
++3.151094490s 9 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.9.0.1
++3.154609629s 7 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.21
++3.154859988s 95 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.14
++3.155601310s 21 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.6
++3.155897033s 77 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.4
++3.156547258s 54 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.7.0.2
++3.157143729s 64 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.25
++3.158103074s 78 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.48
++3.159346353s 73 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.9
++3.161087239s 73 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.53
++3.161370705s 90 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.7
++3.162273369s 74 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.4
++3.163963882s 51 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.11.0.1
++3.166962292s 20 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.6
++3.168710493s 95 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.8
++3.172359229s 84 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.45
++3.176223256s 90 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.3.0.44
++3.177685578s 93 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.15
++3.183003895s 37 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.4
++3.185684895s 47 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.42
++3.187142590s 70 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.56
++3.187947606s 90 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.20
++3.188870765s 85 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.6
++3.190208506s 86 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.19
++3.191049471s 21 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.5
++3.191625849s 75 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.51
++3.191768506s 92 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.6
++3.192460129s 92 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.44
++3.195146264s 2 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.22
++3.197294297s 3 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.11.0.1
++3.198756875s 74 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.4
++3.200000000s 10 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.9.0.1
++3.200000000s 13 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.48
++3.200000000s 14 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.2
++3.200000000s 18 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.6
++3.200000000s 19 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.6
++3.200000000s 42 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.55
++3.200000000s 47 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.6
++3.200000000s 60 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.42
++3.200000000s 62 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.36
++3.200000000s 65 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++3.200000000s 68 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.2
++3.200000000s 69 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.2
++3.200000000s 83 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.39
++3.200000000s 90 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++3.200000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++3.200000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.21
++3.200000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++3.200000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++3.200000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.9
++3.200000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.34
++3.200000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++3.200000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.9
++3.202306331s 19 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.6
++3.206093347s 4 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.28
++3.208836542s 83 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.34
++3.209345085s 87 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.32
++3.211935797s 84 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.8
++3.212411671s 23 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.9.0.1
++3.212433828s 82 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.21
++3.213148701s 9 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.51
++3.213748833s 38 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.8
++3.216301508s 90 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.1
++3.216481337s 42 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.3
++3.216993396s 48 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.15
++3.217022252s 33 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.1
++3.217131526s 19 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.23
++3.217723294s 62 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.36
++3.217879715s 92 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.1
++3.218301645s 43 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.9
++3.219140954s 10 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.43
++3.221859354s 81 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.29
++3.223333053s 87 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.54
++3.224221933s 37 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.6
++3.226182059s 68 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.3
++3.226575797s 58 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.40
++3.230656372s 63 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.1
++3.231065416s 68 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.2
++3.232611762s 60 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.4
++3.233390135s 86 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.21
++3.238238987s 97 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.49
++3.239119629s 82 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.19
++3.239131915s 42 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.55
++3.239876389s 61 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.11.0.1
++3.241391671s 74 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.9.0.1
++3.246598798s 24 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.46
++3.250017524s 14 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.29
++3.250059040s 62 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.38
++3.250452023s 28 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.20
++3.254240972s 47 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.9
++3.256077902s 18 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.9
++3.258690341s 77 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.20
++3.259943347s 50 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.4
++3.272327569s 43 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.20
++3.273506530s 68 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.4
++3.275817431s 45 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.19
++3.276086768s 13 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.9.0.1
++3.276657580s 95 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.1.0.9
++3.278735639s 65 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.10
++3.281924231s 43 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.7
++3.282426194s 14 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.9.0.1
++3.287329314s 90 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.6
++3.287627634s 6 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.7.0.1
++3.289021742s 89 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.51
++3.289280220s 3 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.46
++3.297876441s 8 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.9.0.1
++3.300000000s 47 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.53
++3.300000000s 52 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.34
++3.300000000s 60 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.17
++3.300000000s 65 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++3.300000000s 69 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.9.0.1
++3.300000000s 90 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++3.300000000s 92 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.45
++3.300000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++3.300000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++3.300000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.8
++3.300000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.42
++3.300000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.46
++3.300000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++3.300000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.13
++3.300000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++3.300039695s 62 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.3.0.38
++3.303693544s 83 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.56
++3.304665076s 62 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.3
++3.306699028s 45 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.8
++3.306971603s 92 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.8
++3.308540000s 67 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.4
++3.309443392s 60 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.51
++3.309996334s 26 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.38
++3.313267072s 56 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.3
++3.320731538s 70 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.10
++3.321556337s 69 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.11.0.1
++3.324497403s 84 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.15
++3.324707535s 83 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.20
++3.325363136s 51 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.14
++3.332278296s 36 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.9.0.1
++3.332780594s 51 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.1
++3.333280963s 6 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.5
++3.334123852s 89 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.18
++3.334973426s 76 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.7
++3.337907910s 47 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.53
++3.338851110s 52 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.34
++3.340882348s 18 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.6
++3.340979131s 65 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.6
++3.350162478s 30 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.9.0.1
++3.351132631s 65 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.9.0.1
++3.356861025s 75 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.25
++3.357366938s 71 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.11.0.1
++3.358273238s 56 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.30
++3.359809721s 97 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.39
++3.361437515s 28 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.43
++3.364332608s 66 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.5.0.10
++3.370199666s 13 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.48
++3.371401269s 69 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.5
++3.373710121s 90 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.26
++3.374428145s 1 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.10
++3.376086768s 13 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.9.0.1
++3.376816773s 23 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.7.0.1
++3.377655485s 85 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.36
++3.400000000s 19 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.2
++3.400000000s 45 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++3.400000000s 60 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.35
++3.400000000s 90 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.13
++3.400000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.47
++3.400000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.11.0.1
++3.400000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.44
++3.400000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.9
++3.400000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.20
++3.400000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.48
++3.400000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++3.400000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++3.405281543s 8 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.7.0.1
++3.405565256s 78 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.3
++3.406969765s 83 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.40
++3.408477278s 20 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.21
++3.410072106s 88 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.23
++3.410255497s 84 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.46
++3.411321897s 86 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.18
++3.412111770s 95 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.52
++3.414138925s 95 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.13
++3.418061320s 83 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.39
++3.420971470s 47 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.6
++3.423987155s 95 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.14
++3.425530999s 92 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.11
++3.432318122s 97 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.47
++3.445904004s 60 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.9.0.1
++3.450055244s 60 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.3.0.40
++3.454147815s 95 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.50
++3.455305828s 70 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.13
++3.463538853s 10 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.9.0.1
++3.464999706s 60 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.4
++3.487768079s 60 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.8
++3.490604124s 60 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.2
++3.492653697s 85 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.22
++3.500000000s 19 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++3.500000000s 45 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.45
++3.500000000s 60 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.21
++3.500000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++3.500000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.18
++3.500000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.7
++3.500000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++3.500000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.10
++3.500000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.15
++3.500000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.5
++3.500000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.5
++3.504210618s 65 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.38
++3.514138925s 95 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.1.0.13
++3.519907631s 45 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.45
++3.524382286s 60 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.42
++3.525254124s 95 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.8
++3.526673803s 95 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.43
++3.527091110s 61 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.3
++3.529863884s 67 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.23
++3.531454963s 86 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.25
++3.557102225s 85 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.47
++3.560570731s 48 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.10
++3.565568413s 90 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.52
++3.566482988s 58 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.5
++3.595312273s 95 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.10
++3.600000000s 19 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.43
++3.600000000s 60 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.53
++3.600000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.4
++3.600000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.8
++3.600000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++3.600000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.56
++3.600000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++3.600000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.17
++3.600000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.35
++3.600000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.9
++3.608276960s 45 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.1
++3.609210665s 19 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.1
++3.612602936s 90 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.14
++3.624159805s 92 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.45
++3.631191775s 72 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.9.0.1
++3.642037900s 69 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.9.0.1
++3.656291659s 60 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.43
++3.662977692s 105 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.5
++3.663939778s 23 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.19
++3.686588006s 64 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.38
++3.688977949s 44 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.5
++3.700000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.11
++3.700000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.33
++3.700000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.13
++3.700000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++3.700000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.9
++3.700000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.28
++3.700000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.5
++3.700000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.18
++3.701613471s 60 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.17
++3.706263510s 90 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.13
++3.712418851s 81 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.23
++3.718724691s 19 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.43
++3.719079629s 60 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.35
++3.731663959s 88 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.38
++3.744466702s 103 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.7
++3.748327604s 74 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.10
++3.768503906s 14 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.10
++3.778237621s 65 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.1.0.19
++3.785779491s 93 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.38
++3.786237344s 67 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.7.0.1
++3.800000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.45
++3.800000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.7
++3.800000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.12
++3.800000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++3.800000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++3.800000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.25
++3.800000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.14
++3.800000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.20
++3.813061725s 95 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.47
++3.859388515s 13 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.5.0.10
++3.878608895s 57 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.38
++3.900000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.5
++3.900000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.39
++3.900000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.1
++3.900000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++3.900000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.13
++3.900000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.42
++3.900000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.4
++3.900000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.11
++3.902408556s 17 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.38
++3.905146467s 60 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.53
++3.908832585s 105 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.4
++3.913248677s 102 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.7
++3.925820294s 60 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.21
++4.000000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.6
++4.000000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.45
++4.000000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.3
++4.000000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.7
++4.000000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.48
++4.000000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.44
++4.000000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++4.000000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.36
++4.015531427s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.6
++4.023298850s 104 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++4.057709956s 75 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.38
++4.100000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.55
++4.100000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.14
++4.100000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++4.100000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.11.0.1
++4.100000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.6
++4.100000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++4.100000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.9.0.1
++4.100000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.42
++4.124685440s 106 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.11
++4.138722464s 43 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.3.0.38
++4.200000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.2
++4.200000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.10
++4.200000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++4.200000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.54
++4.200000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.16
++4.200000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.49
++4.200000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++4.237026225s 11 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.8
++4.300000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.55
++4.300000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++4.300000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.35
++4.300000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.4
++4.300000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.56
++4.300000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++4.300000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.46
++4.400000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++4.400000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.4
++4.400000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.35
++4.400000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.8
++4.400000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.36
++4.400000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.47
++4.400000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.17
++4.400000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.43
++4.469510387s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.4
++4.500000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++4.500000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++4.500000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.33
++4.500000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.3
++4.500000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.47
++4.500000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.2
++4.500000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.2
++4.500000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.13
++4.503502781s 105 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.2
++4.505252803s 100 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.7
++4.554264674s 102 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++4.600000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.3
++4.600000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.3
++4.600000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++4.600000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.55
++4.600000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.17
++4.600000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++4.600000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.54
++4.600000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.48
++4.700000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.11
++4.700000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++4.700000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.34
++4.700000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++4.700000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.7
++4.700000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.9.0.1
++4.700000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.10
++4.800000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.31
++4.800000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.13
++4.800000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.12
++4.800000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++4.800000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++4.800000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.18
++4.800000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.20
++4.900000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.35
++4.900000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++4.900000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.1
++4.900000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.34
++4.900000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.18
++4.900000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.31
++4.900000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.7
++4.900000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.44
++4.923627581s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.1
++4.935442138s 99 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.3
++5.000000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.7
++5.000000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.51
++5.000000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.2
++5.000000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.18
++5.000000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.32
++5.000000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.18
++5.000000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++5.000000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.54
++5.100000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.2
++5.100000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.13
++5.100000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++5.100000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++5.100000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.37
++5.100000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.4
++5.100000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.10
++5.100000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.4
++5.117207587s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.2
++5.125809269s 100 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++5.200000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.48
++5.200000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.9
++5.200000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.3
++5.200000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.11.0.1
++5.200000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.18
++5.200000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.4
++5.238775778s 78 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.8
++5.300000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.17
++5.300000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++5.300000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++5.300000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.11
++5.300000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.12
++5.300000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.14
++5.300000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++5.300000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++5.400000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.41
++5.400000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.13
++5.400000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.13
++5.400000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++5.400000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.39
++5.400000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.15
++5.400000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++5.400000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.32
++5.500000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.19
++5.500000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.40
++5.500000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.3
++5.500000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.9
++5.500000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++5.500000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.57
++5.500000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.11
++5.500000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.1
++5.586648877s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.51
++5.600000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.16
++5.600000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.22
++5.600000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.8
++5.600000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.17
++5.600000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.4
++5.600000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++5.600000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++5.600000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++5.700000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++5.700000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.12
++5.700000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.18
++5.700000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.54
++5.700000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.5
++5.700000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.10
++5.700000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.4
++5.729968632s 73 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++5.775554839s 104 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.48
++5.800000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++5.800000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++5.800000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.3
++5.800000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.51
++5.800000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.41
++5.800000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.9
++5.800000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.17
++5.900000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.36
++5.900000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.45
++5.900000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.11
++5.900000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.12
++5.900000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++5.900000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.12
++5.900000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.5
++5.900000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.30
++5.913330950s 70 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.6
++6.000000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.26
++6.000000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.6
++6.000000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.15
++6.000000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++6.000000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.11
++6.000000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.11
++6.000000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.33
++6.100000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.18
++6.100000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.54
++6.100000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.54
++6.100000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++6.100000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.57
++6.100000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.7
++6.100000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.37
++6.100000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.41
++6.200000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.5
++6.200000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.49
++6.200000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.4
++6.200000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.10
++6.200000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++6.200000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.41
++6.200000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++6.200000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.37
++6.300000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.7
++6.300000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++6.300000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++6.300000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++6.300000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.56
++6.300000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.15
++6.300000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++6.400000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++6.400000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.18
++6.400000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.16
++6.400000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.11
++6.400000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++6.400000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.21
++6.400000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.15
++6.500000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.31
++6.500000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.10
++6.500000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.21
++6.500000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.6
++6.500000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.42
++6.500000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.12
++6.500000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.41
++6.500000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.10
++6.508363366s 102 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.6
++6.512545242s 104 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.4
++6.600000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.31
++6.600000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.15
++6.600000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.25
++6.600000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.31
++6.600000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.28
++6.600000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++6.600000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.18
++6.700000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.2
++6.700000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.8
++6.700000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++6.700000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.35
++6.700000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.9
++6.700000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.4
++6.715245082s 106 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.4
++6.722864797s 102 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.8
++6.800000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.4
++6.800000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.49
++6.800000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.2
++6.800000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.13
++6.800000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++6.800000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.36
++6.800000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.9
++6.800000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.18
++6.838907551s 102 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.56
++6.848680063s 104 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.17
++6.900000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.34
++6.900000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.12
++6.900000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.5
++6.900000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.15
++6.900000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.46
++6.900000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.36
++6.900000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.53
++6.900000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++6.958371479s 78 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.4
++6.972964288s 39 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.6
++7.000000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.11
++7.000000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.17
++7.000000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++7.000000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.17
++7.000000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.57
++7.000000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.18
++7.000000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.42
++7.000000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++7.100000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.55
++7.100000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.16
++7.100000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++7.100000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++7.100000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.36
++7.100000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.3
++7.100000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.36
++7.100000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++7.109452300s 104 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.3
++7.114172342s 101 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.6
++7.200000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.6
++7.200000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.32
++7.200000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.19
++7.200000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.18
++7.200000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.3
++7.200000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++7.200000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.44
++7.200000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.5
++7.300000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.33
++7.300000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.5
++7.300000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.3
++7.300000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.26
++7.300000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.26
++7.300000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.6
++7.300000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.40
++7.300000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.31
++7.370600577s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.3
++7.400000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.4
++7.400000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++7.400000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.54
++7.400000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.1
++7.400000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++7.400000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++7.400000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.18
++7.400000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.19
++7.409126424s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.10
++7.422541441s 102 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.1
++7.426645987s 104 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.16
++7.433809891s 99 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.4
++7.455898573s 101 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++7.464187399s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.5
++7.500000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.37
++7.500000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.25
++7.500000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.16
++7.500000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.6
++7.500000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.32
++7.500000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.3
++7.500000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++7.500000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.49
++7.513687760s 10 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++7.539944267s 16 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.6
++7.546278563s 103 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++7.600000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.39
++7.600000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.12
++7.600000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++7.600000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.12
++7.600000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.25
++7.600000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.35
++7.600000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.11
++7.600000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.16
++7.700000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.3
++7.700000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.2
++7.700000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.23
++7.700000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.16
++7.700000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.12
++7.700000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.32
++7.700000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++7.700000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.9
++7.800000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.16
++7.800000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.33
++7.800000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.2
++7.800000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.44
++7.800000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.57
++7.800000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.34
++7.800000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++7.811133715s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.2
++7.816695957s 100 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.3
++7.900000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.2
++7.900000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++7.900000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.57
++7.900000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.45
++7.900000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.42
++7.900000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.8
++7.900000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.48
++7.900000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++7.908230337s 104 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.8
++7.912336889s 106 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.6
++8.000000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.44
++8.000000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.3
++8.000000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.10
++8.000000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++8.000000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.31
++8.000000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.11
++8.000000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.17
++8.000000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.6
++8.100000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.15
++8.100000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.16
++8.100000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.10
++8.100000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.12
++8.100000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++8.100000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.28
++8.100000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.47
++8.200000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.11.0.1
++8.200000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.17
++8.200000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.16
++8.200000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.51
++8.200000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++8.200000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.12
++8.200000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++8.200000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.15
++8.249102697s 105 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.17
++8.300000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.17
++8.300000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.37
++8.300000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++8.300000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++8.300000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.4
++8.300000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.57
++8.300000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.10
++8.328628697s 102 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.10
++8.373626681s 39 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.7
++8.400000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.13
++8.400000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.33
++8.400000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.4
++8.400000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.11
++8.400000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++8.400000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.42
++8.400000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++8.400000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.9.0.1
++8.417057202s 105 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.3
++8.442939228s 90 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.4
++8.500000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++8.500000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.1
++8.500000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.3
++8.500000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.37
++8.500000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.8
++8.500000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.8
++8.500000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++8.525589400s 3 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.7
++8.600000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.44
++8.600000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.5
++8.600000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.11
++8.600000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.40
++8.600000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.45
++8.600000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.6
++8.600000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.22
++8.600000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.10
++8.700000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.57
++8.700000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.15
++8.700000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.6
++8.700000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++8.700000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.16
++8.700000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.42
++8.700000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.54
++8.700000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++8.800000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.2
++8.800000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.17
++8.800000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.17
++8.800000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.49
++8.800000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.4
++8.800000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.15
++8.800000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.49
++8.900000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.23
++8.900000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.57
++8.900000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.1
++8.900000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.51
++8.900000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.16
++8.900000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.26
++8.900000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.19
++9.000000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++9.000000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.45
++9.000000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.3
++9.000000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.23
++9.000000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.3
++9.000000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.26
++9.000000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.54
++9.000000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.21
++9.100000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.28
++9.100000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.12
++9.100000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++9.100000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.25
++9.100000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.2
++9.100000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.24
++9.100000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.4
++9.200000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.40
++9.200000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++9.200000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.9
++9.200000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.30
++9.200000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.42
++9.200000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.28
++9.300000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.11
++9.300000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.14
++9.300000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.20
++9.300000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.53
++9.300000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.11.0.1
++9.300000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.39
++9.300000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.35
++9.347103913s 102 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.50
++9.400000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.19
++9.400000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.41
++9.400000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.2
++9.400000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.5
++9.400000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.16
++9.400000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++9.400000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.5
++9.400000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.9
++9.470620233s 72 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.4
++9.500000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.7
++9.500000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.46
++9.500000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.51
++9.500000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.25
++9.500000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.2
++9.500000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.13
++9.500000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.2
++9.600000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++9.600000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.19
++9.600000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++9.600000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.36
++9.600000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.8
++9.600000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.7
++9.600000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.11
++9.600000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.49
++9.700000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.16
++9.700000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.8
++9.700000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.12
++9.700000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.9
++9.700000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.34
++9.700000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.9
++9.800000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.46
++9.800000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.19
++9.800000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++9.800000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.32
++9.800000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++9.800000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.20
++9.800000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.4
++9.800000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.33
++9.857377525s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.25
++9.900000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++9.900000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++9.900000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.16
++9.900000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.3
++9.900000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.12
++9.900000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.20
++9.900000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++9.900000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.37
++9.986064328s 47 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.3
++10.000000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.45
++10.000000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.26
++10.000000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.44
++10.000000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.47
++10.000000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.45
++10.000000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.8
++10.000000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.3
++10.000000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.9.0.1
++10.009928704s 105 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.3
++10.014888505s 101 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.7
++10.100000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.7
++10.100000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++10.100000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.13
++10.100000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.12
++10.100000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.18
++10.100000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.4
++10.100000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.13
++10.144692174s 104 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.20
++10.200000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++10.200000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.1
++10.200000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.7
++10.200000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.2
++10.200000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++10.200000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.35
++10.200000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.10
++10.200000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++10.210039526s 102 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.2
++10.215055661s 100 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.4
++10.267028389s 42 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.6
++10.300000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.5
++10.300000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.11
++10.300000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.15
++10.300000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.7
++10.300000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.39
++10.300000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.15
++10.300000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.2
++10.300000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.47
++10.340863445s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.11
++10.400000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.8
++10.400000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.5
++10.400000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++10.400000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.23
++10.400000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.2
++10.400000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.10
++10.400000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.56
++10.431911205s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.32
++10.500000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.9
++10.500000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.55
++10.500000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.10
++10.500000000s 102 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.8
++10.500000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++10.500000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.3
++10.500000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.2
++10.500000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.1
++10.511286754s 33 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++10.547858991s 54 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++10.562062922s 102 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.6
++10.593083641s 86 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.4
++10.600000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.44
++10.600000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.14
++10.600000000s 104 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.32
++10.600000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.5
++10.600000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.42
++10.636095308s 104 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.8
++10.700000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.10
++10.700000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++10.700000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++10.700000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.6
++10.700000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.25
++10.700000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.1
++10.754121195s 30 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.6
++10.800000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.3
++10.800000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++10.800000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.9
++10.800000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.33
++10.800000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.21
++10.800000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.55
++10.900000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.8
++10.900000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++10.900000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++10.900000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.11
++10.900000000s 105 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.23
++10.900000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++10.928250457s 105 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.2
++10.945828957s 102 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.16
++11.000000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++11.000000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++11.000000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++11.000000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++11.042086563s 93 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.7
++11.068077232s 38 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.4
++11.100000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++11.100000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.53
++11.100000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.5
++11.100000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.12
++11.100000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.14
++11.200000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.15
++11.200000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++11.200000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++11.200000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.5
++11.300000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.1
++11.300000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++11.300000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.24
++11.300000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.2
++11.300000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.32
++11.318366781s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.42
++11.400000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.40
++11.400000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.39
++11.400000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.6
++11.400000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.16
++11.400000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.12
++11.500000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.7
++11.500000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.8
++11.500000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.19
++11.500000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++11.500000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++11.527571435s 64 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++11.600000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.20
++11.600000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.5
++11.600000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.49
++11.600000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++11.600000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.2
++11.700000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.8
++11.700000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++11.700000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.21
++11.700000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.21
++11.800000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.49
++11.800000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++11.800000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++11.800000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++11.800000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.14
++11.900000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.56
++11.900000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.9
++11.900000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.19
++11.900000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.17
++11.900000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.1
++12.000000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.45
++12.000000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.53
++12.000000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.26
++12.000000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++12.000000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.21
++12.006186828s 4 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.7
++12.012310948s 52 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.5
++12.072636538s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.11.0.1
++12.100000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.53
++12.100000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.20
++12.100000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++12.100000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.8
++12.149984044s 106 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.19
++12.200000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.22
++12.200000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.34
++12.200000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.22
++12.200000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.12
++12.200000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.3
++12.258938517s 97 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++12.274977218s 41 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.8
++12.300000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.17
++12.300000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.51
++12.300000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.9.0.1
++12.300000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.44
++12.300000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.43
++12.400000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++12.400000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.6
++12.400000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.4
++12.400000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++12.400000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.28
++12.427619732s 105 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.14
++12.453117541s 106 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.9
++12.500000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.5
++12.500000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.15
++12.500000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++12.500000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.9
++12.500000000s 106 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.35
++12.540625204s 14 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.7
++12.573215596s 106 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.2
++12.579674345s 31 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.8
++12.600000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.31
++12.600000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.1
++12.600000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++12.600000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.17
++12.609810059s 82 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.8
++12.642127386s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.47
++12.700000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.7
++12.700000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.33
++12.700000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.35
++12.700000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.56
++12.763187814s 69 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++12.800000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++12.800000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.11
++12.800000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.19
++12.800000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.44
++12.900000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.4
++12.900000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.28
++12.900000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.5
++13.000000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.16
++13.000000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.30
++13.000000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++13.000000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++13.044803743s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.19
++13.100000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.21
++13.100000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.12
++13.100000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.51
++13.100000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.51
++13.150257954s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.8
++13.167195448s 41 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++13.200000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++13.200000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.57
++13.200000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++13.237138321s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.26
++13.275375260s 30 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++13.300000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++13.300000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.6
++13.300000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.6
++13.300000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.39
++13.355705587s 48 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++13.400000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.24
++13.400000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.24
++13.400000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++13.400000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.57
++13.451913053s 104 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.35
++13.500000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.21
++13.500000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.13
++13.500000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.31
++13.500000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++13.577863299s 57 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.6
++13.600000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.5
++13.600000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.40
++13.600000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.4
++13.600000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.5
++13.638140380s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.1
++13.700000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.3
++13.700000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.30
++13.700000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++13.700000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++13.757183739s 1 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.3
++13.796606328s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.23
++13.800000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.10
++13.800000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.11
++13.800000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++13.800000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.17
++13.900000000s 99 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.17
++13.900000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++13.900000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++13.900000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++13.921657151s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.10
++13.994900628s 45 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++14.000000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.6
++14.000000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.44
++14.000000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.10
++14.032467993s 10 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++14.100000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.47
++14.100000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.29
++14.100000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.10
++14.200000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.13.0.6
++14.200000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.8
++14.200000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++14.203043144s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.6
++14.204561061s 104 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++14.300000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.4
++14.300000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.24
++14.300000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++14.341324538s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.14
++14.347668740s 106 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.14
++14.400000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++14.400000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.36
++14.400000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.2
++14.461181670s 14 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++14.471496918s 36 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.8
++14.500000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.49
++14.500000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.28
++14.500000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.9
++14.600000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++14.600000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++14.700000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.54
++14.700000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.9
++14.700000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.39
++14.800000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.19
++14.800000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++14.800000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.56
++14.900000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.14
++14.900000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.7
++14.900000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++14.977751001s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.3
++15.000000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++15.000000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.46
++15.100000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.31
++15.100000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++15.100000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++15.125907403s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.11
++15.166621394s 3 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++15.200000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++15.200000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.52
++15.200000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.51
++15.238856785s 11 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.3
++15.300000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.43
++15.300000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.46
++15.314448272s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.6
++15.400000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++15.400000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.11
++15.400000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++15.500000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.21
++15.500000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.17
++15.500000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.54
++15.521665544s 28 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++15.600000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.9.0.1
++15.600000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.21
++15.600000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.21
++15.700000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.11
++15.700000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.4
++15.700000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.47
++15.725645628s 104 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.12
++15.770712274s 105 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.9
++15.800000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.40
++15.800000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++15.800000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.33
++15.806073281s 89 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.7
++15.838472104s 12 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.6
++15.900000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.7
++15.900000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.22
++16.000000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++16.000000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.8
++16.100000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.3
++16.100000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.19
++16.200000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.36
++16.200000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.10
++16.200000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.9
++16.300000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.3
++16.300000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.9.0.1
++16.300000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.4
++16.400000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++16.400000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.34
++16.400000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++16.500000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.34
++16.500000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.12
++16.600000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.49
++16.600000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.6
++16.600000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.41
++16.700000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.35
++16.700000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.28
++16.800000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.9
++16.800000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.32
++16.900000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.2
++16.900000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.24
++16.900000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.4
++17.000000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.25
++17.000000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++17.000000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.53
++17.037517854s 105 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.34
++17.100000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.37
++17.100000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.18
++17.156274487s 56 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.7
++17.200000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.40
++17.200000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.38
++17.200000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.30
++17.300000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.3
++17.300000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.5
++17.300000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.15
++17.400000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.22
++17.400000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.15
++17.500000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.12
++17.500000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.24
++17.500000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.2
++17.600000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.3
++17.600000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.10
++17.600000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.10
++17.700000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.12
++17.700000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.10
++17.700000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.7.0.1
++17.800000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++17.800000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.10
++17.815554467s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.10
++17.900000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.4
++17.900000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.48
++17.900000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.8
++17.923325869s 10 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.3
++18.000000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.57
++18.000000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.19
++18.000000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.17
++18.100000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++18.100000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.37
++18.100000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++18.200000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.53
++18.200000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.20
++18.200000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.16
++18.300000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.23
++18.300000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.9
++18.300000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.2
++18.400000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.23
++18.400000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.7
++18.500000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.11
++18.500000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++18.600000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.1
++18.600000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.56
++18.600000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.21
++18.700000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.41
++18.700000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.30
++18.700000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.9
++18.800000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.6
++18.800000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.50
++18.800000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.25
++18.900000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.5.0.1
++18.900000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.19
++18.900000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.17
++19.000000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.16
++19.000000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.39
++19.100000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.18
++19.100000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.48
++19.200000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.39
++19.200000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.13
++19.200000000s 103 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.4
++19.210441202s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.25
++19.300000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++19.327004143s 102 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.13
++19.400000000s 100 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.1.0.12
++19.400000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.27
++19.415653980s 47 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++19.440499763s 13 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.4
++19.497416900s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.12
++19.500000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.7
++19.518260980s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.3
++19.600000000s 101 BNSMincastNode:InitOutgoingConnection(): [INFO ] Connecting to address 10.3.0.4
++19.627395332s 3 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++19.638788691s 106 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.56
++19.645140739s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.34
++19.695592877s 34 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++19.758190129s 78 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.13.0.8
++19.767709592s 56 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.3
++19.801210297s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.50
++20.001798699s 72 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++20.086888591s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.28
++20.280330399s 50 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++20.332027814s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.37
++20.448051148s 59 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++20.540774193s 104 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.14
++20.562807564s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.17
++20.642695663s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.15
++20.661158989s 36 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.6
++20.694183208s 39 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++20.764021653s 15 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.3
++22.618260980s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.1.0.3
++22.727395332s 3 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.13.0.2
++22.751517727s 106 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.49
++22.877272232s 71 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.8
++23.529206176s 23 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.2
++24.055516720s 105 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.6
++24.083271326s 86 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.7
++24.834586768s 104 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.7
++24.942116229s 102 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.5
++24.951871861s 29 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.6
++25.063173433s 27 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.4
++25.435879687s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.36
++25.553820529s 58 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++25.740285775s 102 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.3
++25.860422776s 25 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.4
++26.307923533s 105 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.10
++26.411882715s 10 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.7
++26.486839615s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.12
++26.680244045s 12 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++26.807420434s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.39
++26.812072449s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.5
++26.918094412s 5 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++27.011114522s 61 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++27.146091642s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.56
++27.231973895s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.57
++27.269141117s 78 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++27.347958386s 79 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++27.362805135s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.18
++27.494207179s 40 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++27.649033271s 104 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.29
++27.773540028s 51 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.6
++28.151222660s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.34
++28.276830953s 56 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++29.555074772s 105 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.8
++29.582631391s 88 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.7
++31.468779578s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.8
++31.503187857s 88 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++31.666873390s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.4
++31.849371562s 4 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++33.527489661s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.2
++33.641218696s 82 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++34.240795796s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.16
++34.361185495s 16 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++34.729998629s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.4
++34.794993853s 84 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.3
++36.454964601s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.6
++36.582445832s 28 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++37.695538095s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.9.0.1
++37.893312180s 95 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.3
++38.970317049s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.10
++39.105450139s 32 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.3
++47.321674339s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.13
++47.432506000s 13 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++47.891375105s 54 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.5
++51.001922470s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.14
++51.202885220s 36 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++51.852386322s 105 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.35
++51.978576327s 57 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.7
++52.066350566s 102 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.7
++52.099545775s 87 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.4
++52.364089901s 106 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.42
++52.496159983s 64 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.8
++52.727910817s 105 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.7.0.2
++52.841746923s 93 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.13.0.7
++56.368185072s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.19
++56.552129384s 19 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++56.666415209s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.24
++56.799617546s 46 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++56.840969273s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.40
++56.961461577s 62 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.3
++57.066350566s 102 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.5.0.7
++57.099545775s 87 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.13.0.4
++58.342447559s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.14
++58.463674268s 36 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++58.959817871s 105 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.7
++58.989746967s 87 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.7
++68.250443904s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.12
++68.250801851s 102 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.55
++68.375133346s 34 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++68.376191066s 77 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.4
++68.957007833s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.4
++69.085509946s 26 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++71.146365540s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.20
++71.269543668s 42 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++75.242785402s 106 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.21
++75.364186512s 21 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.8
++95.452054095s 55 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.13.0.4
++96.034957407s 104 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.46
++96.152431012s 68 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.6
++97.487915210s 105 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.9.0.1
++97.681877075s 95 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.7
++98.451328963s 106 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.15
++98.576998755s 37 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.8
++99.135486266s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.45
++99.253228214s 67 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++100.733279811s 104 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.3
++100.849910940s 25 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.6
++101.228198213s 102 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.18
++101.342293212s 18 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.4
++102.349017963s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.54
++102.352157966s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.53
++102.473526256s 76 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++102.478233854s 75 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++104.339656051s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.53
++104.459482433s 75 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++105.247988181s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.45
++105.371979635s 67 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++105.453240133s 102 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.9
++105.566329830s 104 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.2
++105.579859427s 31 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.4
++105.599480911s 82 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.6
++105.636786425s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.5
++105.755179670s 27 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++106.533611771s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.51
++106.750418061s 73 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++107.556277663s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.8
++107.577729075s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.1.0.3
++107.584436436s 88 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++107.618254164s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.1.0.3
++107.727388516s 3 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.13.0.2
++107.766599468s 3 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.13.0.5
++108.047637740s 104 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.41
++108.171415806s 63 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.6
++108.696108478s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.46
++108.853288441s 104 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.6
++108.894160037s 68 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++108.979927759s 28 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.6
++109.015130155s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.19
++109.122548492s 19 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.3
++109.438431194s 105 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.44
++109.557645048s 66 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.7
++110.542829758s 104 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.4
++110.664240452s 26 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.6
++111.599304947s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.16
++111.665688540s 104 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.27
++111.798529215s 49 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.6
++111.798625304s 38 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++111.926839611s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.27
++112.140258240s 49 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++114.147910329s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.9
++114.183650993s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.48
++114.196261336s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.5
++114.271865664s 31 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++114.325479083s 70 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.3
++114.394390622s 27 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++119.877560086s 106 BNSMincastNode:HandlePeerClose(): [INFO ] Outgoing connection CLOSED: 10.3.0.56
++120.071533728s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.5
++120.257291732s 5 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++120.330808449s 105 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.37
++120.446229629s 59 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.7
++120.538132331s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.1.0.1
++120.657175690s 1 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.13.0.3
++121.053557515s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.2
++121.180337154s 24 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.3
++122.159639436s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.2
++122.289458515s 24 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++122.745379211s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.1
++122.868067455s 92 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++123.858867455s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.20
++123.988295089s 42 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++124.035533702s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.2
++124.153182028s 93 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.3
++124.247988181s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.3.0.45
++124.371979635s 67 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.13.0.1
++126.438720745s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.34
++126.558079532s 56 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++127.472831793s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.21
++127.659246362s 43 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++130.846308121s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.49
++130.969461157s 71 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++143.954347767s 102 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.54
++144.081520019s 76 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.4
++149.643140020s 106 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.12
++149.764181425s 34 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.8
++151.721674339s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection CANCELED: 10.1.0.13
++151.832506000s 13 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection REFUSED (already connected): 10.13.0.2
++153.358420965s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.31
++153.487652724s 53 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++155.534955971s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.3
++155.652429013s 25 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++156.447123357s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.1.0.20
++156.570672494s 20 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.3
++156.959256031s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.30
++157.088885309s 52 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.3
++191.750577242s 106 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.1
++191.875866955s 92 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.8
++192.041375965s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.3
++192.127278579s 105 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.5.0.5
++192.162059073s 25 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.3
++192.240917575s 85 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.7
++194.252136000s 99 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.44
++194.378201514s 66 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.1
++194.530764188s 105 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.57
++194.646146525s 79 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.7
++195.151799205s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.7.0.1
++195.277697515s 92 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.3
++196.141735386s 100 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.50
++196.262587747s 72 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.2
++198.960009207s 101 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.35
++199.090011432s 57 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.3
++199.791441990s 103 BNSMincastNode:HandleConnect(): [INFO ] Outgoing connection ESTABLISHED: 10.3.0.57
++199.987162522s 79 BNSMincastNode:HandleAccept(): [INFO ] Incoming connection ESTABLISHED: 10.13.0.5
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] Starting mining on new block. Prev ID:0, Prev Height: 0, will be found in 906.467 seconds.
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] 
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] 
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] 
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] Start to broadcast 10 seconds after the simulation starts
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] Start to broadcast 10 seconds after the simulation starts
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] Start to broadcast 10 seconds after the simulation starts
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] Start to broadcast 10 seconds after the simulation starts
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] Start to broadcast 10 seconds after the simulation starts
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] Start to broadcast 10 seconds after the simulation starts
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] Start to broadcast 10 seconds after the simulation starts
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] 
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] 
++202.000000000s 21 BNSBitcoinMiner:StartMining(): [INFO ] 
++10202.000000000s 21 BNSBitcoinMiner:MineBlock(): [INFO ] MineBlock Now
++10202.000000000s 21 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10202.000000000s 21 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10202.000000000s 21 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Mined new BLOCK 15317077935894562816 size: 1110788
++10203.938984561s 9 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10203.938984561s 9 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10203.938984561s 9 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10204.166910775s 10 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10204.166910775s 10 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10204.166910775s 10 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10204.207782274s 17 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10204.207782274s 17 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10204.207782274s 17 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10205.552490483s 6 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10205.552490483s 6 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10205.552490483s 6 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10206.376484533s 19 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10206.376484533s 19 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10206.376484533s 19 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10206.637829688s 5 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10206.637829688s 5 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10206.637829688s 5 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10206.754370488s 4 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10206.754370488s 4 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10206.754370488s 4 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10207.168730426s 7 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10207.168730426s 7 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10207.168730426s 7 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10207.216591090s 25 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10207.216591090s 25 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10207.216591090s 25 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10207.322565195s 29 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10207.322565195s 29 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10207.322565195s 29 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10207.346194791s 58 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10207.346194791s 58 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10207.346194791s 58 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10207.367524799s 69 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10207.367524799s 69 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10207.367524799s 69 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10207.373323515s 45 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10207.373323515s 45 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10207.373323515s 45 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10207.452864304s 48 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10207.452864304s 48 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10207.452864304s 48 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10207.491590947s 75 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10207.491590947s 75 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10207.491590947s 75 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10207.531169650s 86 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10207.531169650s 86 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10207.531169650s 86 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10207.557725381s 24 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10207.557725381s 24 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10207.557725381s 24 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10207.588924443s 81 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10207.588924443s 81 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10207.588924443s 81 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10207.610493130s 36 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10207.610493130s 36 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10207.610493130s 36 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10207.649975049s 52 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10207.649975049s 52 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10207.649975049s 52 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10207.805597360s 89 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10207.805597360s 89 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10207.805597360s 89 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10207.978754928s 53 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10207.978754928s 53 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10207.978754928s 53 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10208.098910370s 20 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10208.098910370s 20 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10208.098910370s 20 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10208.723798192s 12 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10208.723798192s 12 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10208.723798192s 12 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10208.913565783s 13 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10208.913565783s 13 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10208.913565783s 13 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10209.052426167s 46 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10209.052426167s 46 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10209.052426167s 46 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10209.057209361s 71 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10209.057209361s 71 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10209.057209361s 71 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10209.148784661s 70 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10209.148784661s 70 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10209.148784661s 70 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10209.230240618s 54 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10209.230240618s 54 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10209.230240618s 54 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10209.339912273s 40 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10209.339912273s 40 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10209.339912273s 40 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10209.621006045s 3 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10209.621006045s 3 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10209.621006045s 3 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10209.821305575s 37 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10209.821305575s 37 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10209.821305575s 37 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10210.003977051s 1 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10210.003977051s 1 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10210.003977051s 1 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10210.189509843s 50 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10210.189509843s 50 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10210.189509843s 50 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10210.308775962s 74 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10210.308775962s 74 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10210.308775962s 74 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10210.323575748s 39 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10210.323575748s 39 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10210.323575748s 39 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10210.444739260s 66 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10210.444739260s 66 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10210.444739260s 66 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10210.466264718s 27 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10210.466264718s 27 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10210.466264718s 27 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10210.523035421s 85 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10210.523035421s 85 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10210.523035421s 85 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10210.524928819s 11 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10210.524928819s 11 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10210.524928819s 11 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10210.534670535s 34 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10210.534670535s 34 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10210.534670535s 34 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10210.623694927s 41 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10210.623694927s 41 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10210.623694927s 41 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10210.684183288s 76 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10210.684183288s 76 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10210.684183288s 76 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10210.783451736s 44 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10210.783451736s 44 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10210.783451736s 44 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10210.835851742s 64 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10210.835851742s 64 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10210.835851742s 64 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10211.083382444s 15 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10211.083382444s 15 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10211.083382444s 15 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10211.268489993s 14 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10211.268489993s 14 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10211.268489993s 14 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10211.684873201s 18 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10211.684873201s 18 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10211.684873201s 18 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10211.805904754s 33 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10211.805904754s 33 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10211.805904754s 33 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10212.128703436s 83 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10212.128703436s 83 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10212.128703436s 83 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10212.952270612s 16 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10212.952270612s 16 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10212.952270612s 16 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10213.084771064s 60 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10213.084771064s 60 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10213.084771064s 60 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10213.902199945s 8 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10213.902199945s 8 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10213.902199945s 8 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10216.775037410s 62 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10216.775037410s 62 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10216.775037410s 62 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10216.953347963s 67 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10216.953347963s 67 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10216.953347963s 67 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10217.288956657s 30 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10217.288956657s 30 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10217.288956657s 30 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10217.705911647s 68 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10217.705911647s 68 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10217.705911647s 68 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10217.959769787s 49 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10217.959769787s 49 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10217.959769787s 49 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10217.970212720s 26 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10217.970212720s 26 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10217.970212720s 26 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10218.222175070s 88 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10218.222175070s 88 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10218.222175070s 88 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10218.351731812s 31 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10218.351731812s 31 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10218.351731812s 31 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10218.450792564s 51 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10218.450792564s 51 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10218.450792564s 51 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10218.532343636s 57 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10218.532343636s 57 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10218.532343636s 57 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10218.659932891s 32 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10218.659932891s 32 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10218.659932891s 32 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10219.044372890s 43 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10219.044372890s 43 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10219.044372890s 43 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10219.140486346s 92 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10219.140486346s 92 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10219.140486346s 92 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10221.835477427s 2 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10221.835477427s 2 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10221.835477427s 2 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10223.666701901s 23 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10223.666701901s 23 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10223.666701901s 23 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10224.145751576s 79 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10224.145751576s 79 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10224.145751576s 79 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10224.430817732s 65 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10224.430817732s 65 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10224.430817732s 65 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10224.689576833s 72 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10224.689576833s 72 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10224.689576833s 72 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10224.823273210s 55 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10224.823273210s 55 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10224.823273210s 55 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10224.895332216s 63 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10224.895332216s 63 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10224.895332216s 63 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10224.961397438s 87 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10224.961397438s 87 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10224.961397438s 87 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10225.026273878s 47 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10225.026273878s 47 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10225.026273878s 47 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10225.401212273s 73 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10225.401212273s 73 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10225.401212273s 73 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10225.774642337s 84 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10225.774642337s 84 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10225.774642337s 84 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10226.198237201s 95 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10226.198237201s 95 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10226.198237201s 95 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10239.868493230s 41 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10239.868493230s 41 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10256.118032533s 68 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.5
++10256.118032533s 68 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10264.498953727s 59 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10264.498953727s 59 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10264.498953727s 59 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10265.593366355s 61 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10265.593366355s 61 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10265.593366355s 61 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10265.753571162s 56 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10265.753571162s 56 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10265.753571162s 56 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10267.019746624s 42 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10267.019746624s 42 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10267.019746624s 42 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10267.874840068s 82 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10267.874840068s 82 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10267.874840068s 82 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10267.933300458s 28 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10267.933300458s 28 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10267.933300458s 28 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10269.936267579s 93 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10269.936267579s 93 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10269.936267579s 93 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10270.062562569s 97 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10270.062562569s 97 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10270.062562569s 97 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10271.189500099s 90 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10271.189500099s 90 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10271.189500099s 90 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10293.271218023s 43 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.1
++10293.271218023s 43 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10325.000000001s 21 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.8
++10325.000000001s 21 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10327.166910776s 10 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10327.166910776s 10 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10327.166910776s 10 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.1
++10327.166910776s 10 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10327.166910776s 10 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.3
++10327.166910776s 10 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10328.504028853s 10 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.7
++10328.504028853s 10 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10329.376484534s 19 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.3
++10329.376484534s 19 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10329.637829689s 5 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10329.637829689s 5 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10329.754370489s 4 BNSMincastNode:HandlePeerError(): [WARN ] Outgoing connection ERROR: 10.13.0.7
++10329.754370489s 4 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10330.216591091s 25 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.3
++10330.216591091s 25 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10330.216591091s 25 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10330.216591091s 25 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10330.216591091s 25 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.4
++10330.216591091s 25 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10330.216591091s 25 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.6
++10330.216591091s 25 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10330.322565196s 29 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.6
++10330.322565196s 29 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10330.346194792s 58 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10330.346194792s 58 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10330.367524800s 69 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.1
++10330.367524800s 69 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10330.452864305s 48 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10330.452864305s 48 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10330.491590948s 75 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10330.491590948s 75 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10330.491590948s 75 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.1
++10330.491590948s 75 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10330.531169651s 86 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.7
++10330.531169651s 86 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10330.531169651s 86 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.4
++10330.531169651s 86 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10330.557725382s 24 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.1
++10330.557725382s 24 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10330.557725382s 24 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.3
++10330.557725382s 24 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10330.610493131s 36 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10330.610493131s 36 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10330.610493131s 36 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.8
++10330.610493131s 36 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10330.610493131s 36 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.6
++10330.610493131s 36 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10330.649975050s 52 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.3
++10330.649975050s 52 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10330.805597361s 89 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.7
++10330.805597361s 89 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10330.978754929s 53 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10330.978754929s 53 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10331.098910371s 20 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.3
++10331.098910371s 20 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10331.723798193s 12 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.6
++10331.723798193s 12 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10331.913565784s 13 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.4
++10331.913565784s 13 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10331.913565784s 13 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10331.913565784s 13 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10332.052426168s 46 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.1
++10332.052426168s 46 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10332.057209362s 71 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10332.057209362s 71 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10332.057209362s 71 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.8
++10332.057209362s 71 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10332.148784662s 70 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.3
++10332.148784662s 70 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10332.148784662s 70 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.6
++10332.148784662s 70 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10332.230240619s 54 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10332.230240619s 54 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10332.339912274s 40 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.1
++10332.339912274s 40 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10332.621006046s 3 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.7
++10332.621006046s 3 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10332.821305576s 37 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.8
++10332.821305576s 37 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10333.003977052s 1 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.3
++10333.003977052s 1 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10333.308775963s 74 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.4
++10333.308775963s 74 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10333.323575749s 39 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.1
++10333.323575749s 39 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10333.323575749s 39 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.7
++10333.323575749s 39 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10333.323575749s 39 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.6
++10333.323575749s 39 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10333.444739261s 66 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.1
++10333.444739261s 66 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10333.444739261s 66 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.7
++10333.444739261s 66 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10333.466264719s 27 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10333.466264719s 27 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10333.466264719s 27 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.4
++10333.466264719s 27 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10333.523035422s 85 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.7
++10333.523035422s 85 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10333.524928820s 11 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.8
++10333.524928820s 11 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10333.524928820s 11 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.3
++10333.524928820s 11 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10333.534670536s 34 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.8
++10333.534670536s 34 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10333.534670536s 34 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.1
++10333.534670536s 34 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10333.623694928s 41 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.8
++10333.623694928s 41 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10333.684183289s 76 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.4
++10333.684183289s 76 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10333.684183289s 76 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10333.684183289s 76 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10333.835851743s 64 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.8
++10333.835851743s 64 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10334.083382445s 15 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.3
++10334.083382445s 15 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10334.268489994s 14 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.1
++10334.268489994s 14 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10334.268489994s 14 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.7
++10334.268489994s 14 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10334.684873202s 18 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.4
++10334.684873202s 18 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10335.952270613s 16 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.6
++10335.952270613s 16 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10335.952270613s 16 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.1
++10335.952270613s 16 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10336.117370489s 4 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.5
++10336.117370489s 4 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10336.117484534s 19 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.5
++10336.117484534s 19 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10336.254904755s 33 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.1
++10336.254904755s 33 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10336.945829689s 5 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.5
++10336.945829689s 5 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10339.775037411s 62 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.3
++10339.775037411s 62 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10339.953347964s 67 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10339.953347964s 67 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10339.953347964s 67 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.1
++10339.953347964s 67 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10340.288956658s 30 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.1
++10340.288956658s 30 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10340.288956658s 30 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.6
++10340.288956658s 30 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10340.705911648s 68 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.6
++10340.705911648s 68 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10340.959769788s 49 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.6
++10340.959769788s 49 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10340.970212721s 26 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.6
++10340.970212721s 26 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10341.063006046s 3 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.5
++10341.063006046s 3 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10341.222175071s 88 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.1
++10341.222175071s 88 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10341.222175071s 88 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.7
++10341.222175071s 88 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10341.351731813s 31 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10341.351731813s 31 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10341.351731813s 31 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.8
++10341.351731813s 31 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10341.351731813s 31 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.4
++10341.351731813s 31 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10341.532343637s 57 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.7
++10341.532343637s 57 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10341.532343637s 57 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.6
++10341.532343637s 57 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10341.532343637s 57 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.3
++10341.532343637s 57 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10341.659932892s 32 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.3
++10341.659932892s 32 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10341.866798193s 12 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.5
++10341.866798193s 12 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10342.140486347s 92 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.3
++10342.140486347s 92 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10342.140486347s 92 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.8
++10342.140486347s 92 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10342.217323516s 45 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.5
++10342.217323516s 45 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10342.707627411s 51 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.6
++10342.707627411s 51 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10343.129240619s 54 BNSMincastNode:HandlePeerError(): [WARN ] Outgoing connection ERROR: 10.13.0.5
++10343.129240619s 54 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10343.332509844s 50 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.5
++10343.332509844s 50 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10343.588493131s 36 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.5
++10343.588493131s 36 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10345.310264719s 27 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.5
++10345.310264719s 27 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10345.517975050s 52 BNSMincastNode:HandlePeerError(): [WARN ] Outgoing connection ERROR: 10.13.0.5
++10345.517975050s 52 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10345.567670536s 34 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.5
++10345.567670536s 34 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10346.666701902s 23 BNSMincastNode:HandlePeerError(): [WARN ] Outgoing connection ERROR: 10.13.0.2
++10346.666701902s 23 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10347.145751577s 79 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10347.145751577s 79 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10347.145751577s 79 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.7
++10347.145751577s 79 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10347.689576834s 72 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10347.689576834s 72 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10347.689576834s 72 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.4
++10347.689576834s 72 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10347.823273211s 55 BNSMincastNode:HandlePeerError(): [WARN ] Outgoing connection ERROR: 10.13.0.4
++10347.823273211s 55 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10347.895332217s 63 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.6
++10347.895332217s 63 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10347.961397439s 87 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.7
++10347.961397439s 87 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10347.961397439s 87 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.4
++10347.961397439s 87 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10348.026273879s 47 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.3
++10348.026273879s 47 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10348.218372891s 43 BNSMincastNode:HandlePeerError(): [WARN ] Outgoing connection ERROR: 10.13.0.3
++10348.218372891s 43 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10348.401212274s 73 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.1
++10348.401212274s 73 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10348.774642338s 84 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.3
++10348.774642338s 84 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10349.837851743s 64 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.5
++10349.837851743s 64 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10358.233751577s 79 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.5
++10358.233751577s 79 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10358.662769788s 49 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.5
++10358.662769788s 49 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10359.530237202s 95 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.7
++10359.530237202s 95 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10360.478576834s 72 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.5
++10360.478576834s 72 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10361.042237202s 95 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.3
++10361.042237202s 95 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10362.516273879s 47 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.5
++10362.516273879s 47 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10364.216750912s 78 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10364.216750912s 78 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10364.216750912s 78 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10365.604888689s 38 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10365.604888689s 38 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10365.604888689s 38 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10366.993516073s 77 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10366.993516073s 77 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10366.993516073s 77 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10367.427212274s 73 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.5
++10367.427212274s 73 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10367.883768303s 35 BNSBlockchain:GetBlockHeight(): [INFO ] Set new height (1) for 15317077935894562816
++10367.883768303s 35 BNSMincastNode:InitBroadcast(): [INFO ] InitBroadcast
++10367.883768303s 35 BNSBitcoinNode:NotifyNewBlock(): [INFO ] Got new BLOCK: 15317077935894562816
++10370.567971297s 103 BNSMincastNode:HandlePeerError(): [WARN ] Outgoing connection ERROR: 10.3.0.46
++10370.567971297s 103 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10387.498953728s 59 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10387.498953728s 59 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10387.498953728s 59 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.7
++10387.498953728s 59 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10388.753571163s 56 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10388.753571163s 56 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10388.753571163s 56 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.7
++10388.753571163s 56 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10388.753571163s 56 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.1
++10388.753571163s 56 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10388.753571163s 56 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.3
++10388.753571163s 56 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10390.019746625s 42 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.1
++10390.019746625s 42 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10390.019746625s 42 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10390.019746625s 42 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10390.019746625s 42 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.6
++10390.019746625s 42 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10390.874840069s 82 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.6
++10390.874840069s 82 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10390.874840069s 82 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.8
++10390.874840069s 82 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10390.874840069s 82 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.5
++10390.874840069s 82 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10390.933300459s 28 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.6
++10390.933300459s 28 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10390.933300459s 28 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10390.933300459s 28 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10392.936267580s 93 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.3
++10392.936267580s 93 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10392.936267580s 93 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.7
++10392.936267580s 93 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10394.189500100s 90 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.4
++10394.189500100s 90 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10400.370562570s 97 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.2
++10400.370562570s 97 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10402.705366356s 61 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.5
++10402.705366356s 61 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10406.179300459s 28 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.5
++10406.179300459s 28 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10487.216750913s 78 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.1
++10487.216750913s 78 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10487.216750913s 78 BNSMincastNode:HandlePeerError(): [WARN ] Outgoing connection ERROR: 10.13.0.8
++10487.216750913s 78 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10487.216750913s 78 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.4
++10487.216750913s 78 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10488.604888690s 38 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.4
++10488.604888690s 38 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10489.993516074s 77 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.4
++10489.993516074s 77 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10501.015888690s 38 BNSMincastNode:HandlePeerError(): [WARN ] Incoming connection ERROR: 10.13.0.5
++10501.015888690s 38 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10518.870091416s 100 BNSMincastNode:HandlePeerError(): [WARN ] Outgoing connection ERROR: 10.3.0.19
++10518.870091416s 100 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10629.021047020s 105 BNSMincastNode:HandlePeerError(): [WARN ] Outgoing connection ERROR: 10.1.0.10
++10629.021047020s 105 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10643.330109811s 104 BNSMincastNode:HandlePeerError(): [WARN ] Outgoing connection ERROR: 10.3.0.29
++10643.330109811s 104 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++10644.465792560s 99 BNSMincastNode:HandlePeerError(): [WARN ] Outgoing connection ERROR: 10.3.0.21
++10644.465792560s 99 BNSMincastNode:HandlePeerError(): [WARN ] Error: ERROR_NOTERROR
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10209582 - 1.0202e+07 =  7582 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10209582 - 1.0202e+07 =  7582 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10221413 - 1.0202e+07 =  19413 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10221413 - 1.0202e+07 =  19413 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10209199 - 1.0202e+07 =  7199 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10209199 - 1.0202e+07 =  7199 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206332 - 1.0202e+07 =  4332 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206332 - 1.0202e+07 =  4332 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206216 - 1.0202e+07 =  4216 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206216 - 1.0202e+07 =  4216 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205130 - 1.0202e+07 =  3130 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205130 - 1.0202e+07 =  3130 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206746 - 1.0202e+07 =  4746 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206746 - 1.0202e+07 =  4746 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10213480 - 1.0202e+07 =  11480 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10213480 - 1.0202e+07 =  11480 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203517 - 1.0202e+07 =  1517 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203517 - 1.0202e+07 =  1517 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203745 - 1.0202e+07 =  1745 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203745 - 1.0202e+07 =  1745 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210103 - 1.0202e+07 =  8103 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210103 - 1.0202e+07 =  8103 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10208302 - 1.0202e+07 =  6302 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10208302 - 1.0202e+07 =  6302 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10208491 - 1.0202e+07 =  6491 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10208491 - 1.0202e+07 =  6491 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210846 - 1.0202e+07 =  8846 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210846 - 1.0202e+07 =  8846 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210661 - 1.0202e+07 =  8661 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210661 - 1.0202e+07 =  8661 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10212530 - 1.0202e+07 =  10530 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10212530 - 1.0202e+07 =  10530 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203786 - 1.0202e+07 =  1786 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10203786 - 1.0202e+07 =  1786 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10211263 - 1.0202e+07 =  9263 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10211263 - 1.0202e+07 =  9263 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205954 - 1.0202e+07 =  3954 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10205954 - 1.0202e+07 =  3954 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207677 - 1.0202e+07 =  5677 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207677 - 1.0202e+07 =  5677 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10202000 - 1.0202e+07 =  0 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10202000 - 1.0202e+07 =  0 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10223244 - 1.0202e+07 =  21244 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10223244 - 1.0202e+07 =  21244 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207135 - 1.0202e+07 =  5135 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207135 - 1.0202e+07 =  5135 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206794 - 1.0202e+07 =  4794 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206794 - 1.0202e+07 =  4794 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10217548 - 1.0202e+07 =  15548 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10217548 - 1.0202e+07 =  15548 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210044 - 1.0202e+07 =  8044 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210044 - 1.0202e+07 =  8044 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10267511 - 1.0202e+07 =  65511 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10267511 - 1.0202e+07 =  65511 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206900 - 1.0202e+07 =  4900 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206900 - 1.0202e+07 =  4900 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10216867 - 1.0202e+07 =  14867 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10216867 - 1.0202e+07 =  14867 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10217929 - 1.0202e+07 =  15929 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10217929 - 1.0202e+07 =  15929 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10218238 - 1.0202e+07 =  16238 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10218238 - 1.0202e+07 =  16238 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10211384 - 1.0202e+07 =  9384 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10211384 - 1.0202e+07 =  9384 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210112 - 1.0202e+07 =  8112 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210112 - 1.0202e+07 =  8112 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10367462 - 1.0202e+07 =  165462 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10367462 - 1.0202e+07 =  165462 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207188 - 1.0202e+07 =  5188 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207188 - 1.0202e+07 =  5188 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10209399 - 1.0202e+07 =  7399 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10209399 - 1.0202e+07 =  7399 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10365183 - 1.0202e+07 =  163183 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10365183 - 1.0202e+07 =  163183 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10209901 - 1.0202e+07 =  7901 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10209901 - 1.0202e+07 =  7901 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10208918 - 1.0202e+07 =  6918 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10208918 - 1.0202e+07 =  6918 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210201 - 1.0202e+07 =  8201 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210201 - 1.0202e+07 =  8201 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10266597 - 1.0202e+07 =  64597 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10266597 - 1.0202e+07 =  64597 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10218622 - 1.0202e+07 =  16622 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10218622 - 1.0202e+07 =  16622 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210361 - 1.0202e+07 =  8361 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210361 - 1.0202e+07 =  8361 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206951 - 1.0202e+07 =  4951 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206951 - 1.0202e+07 =  4951 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10208630 - 1.0202e+07 =  6630 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10208630 - 1.0202e+07 =  6630 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10224604 - 1.0202e+07 =  22604 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10224604 - 1.0202e+07 =  22604 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207031 - 1.0202e+07 =  5031 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207031 - 1.0202e+07 =  5031 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10217538 - 1.0202e+07 =  15538 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10217538 - 1.0202e+07 =  15538 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10209767 - 1.0202e+07 =  7767 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10209767 - 1.0202e+07 =  7767 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10218029 - 1.0202e+07 =  16029 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10218029 - 1.0202e+07 =  16029 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207228 - 1.0202e+07 =  5228 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207228 - 1.0202e+07 =  5228 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207556 - 1.0202e+07 =  5556 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207556 - 1.0202e+07 =  5556 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10208808 - 1.0202e+07 =  6808 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10208808 - 1.0202e+07 =  6808 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10224401 - 1.0202e+07 =  22401 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10224401 - 1.0202e+07 =  22401 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10265331 - 1.0202e+07 =  63331 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10265331 - 1.0202e+07 =  63331 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10218110 - 1.0202e+07 =  16110 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10218110 - 1.0202e+07 =  16110 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206924 - 1.0202e+07 =  4924 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206924 - 1.0202e+07 =  4924 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10264077 - 1.0202e+07 =  62077 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10264077 - 1.0202e+07 =  62077 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10212663 - 1.0202e+07 =  10663 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10212663 - 1.0202e+07 =  10663 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10265171 - 1.0202e+07 =  63171 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10265171 - 1.0202e+07 =  63171 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10216353 - 1.0202e+07 =  14353 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10216353 - 1.0202e+07 =  14353 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10224473 - 1.0202e+07 =  22473 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10224473 - 1.0202e+07 =  22473 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210414 - 1.0202e+07 =  8414 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210414 - 1.0202e+07 =  8414 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10224009 - 1.0202e+07 =  22009 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10224009 - 1.0202e+07 =  22009 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210022 - 1.0202e+07 =  8022 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210022 - 1.0202e+07 =  8022 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10216531 - 1.0202e+07 =  14531 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10216531 - 1.0202e+07 =  14531 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10217284 - 1.0202e+07 =  15284 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10217284 - 1.0202e+07 =  15284 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206945 - 1.0202e+07 =  4945 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10206945 - 1.0202e+07 =  4945 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10208727 - 1.0202e+07 =  6727 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10208727 - 1.0202e+07 =  6727 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10208635 - 1.0202e+07 =  6635 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10208635 - 1.0202e+07 =  6635 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10224267 - 1.0202e+07 =  22267 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10224267 - 1.0202e+07 =  22267 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10224979 - 1.0202e+07 =  22979 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10224979 - 1.0202e+07 =  22979 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10209887 - 1.0202e+07 =  7887 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10209887 - 1.0202e+07 =  7887 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207069 - 1.0202e+07 =  5069 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207069 - 1.0202e+07 =  5069 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210262 - 1.0202e+07 =  8262 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210262 - 1.0202e+07 =  8262 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10366571 - 1.0202e+07 =  164571 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10366571 - 1.0202e+07 =  164571 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10363794 - 1.0202e+07 =  161794 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10363794 - 1.0202e+07 =  161794 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10223723 - 1.0202e+07 =  21723 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10223723 - 1.0202e+07 =  21723 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207167 - 1.0202e+07 =  5167 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207167 - 1.0202e+07 =  5167 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10267453 - 1.0202e+07 =  65453 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10267453 - 1.0202e+07 =  65453 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10211706 - 1.0202e+07 =  9706 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10211706 - 1.0202e+07 =  9706 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10225352 - 1.0202e+07 =  23352 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10225352 - 1.0202e+07 =  23352 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210101 - 1.0202e+07 =  8101 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10210101 - 1.0202e+07 =  8101 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207109 - 1.0202e+07 =  5109 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207109 - 1.0202e+07 =  5109 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10224539 - 1.0202e+07 =  22539 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10224539 - 1.0202e+07 =  22539 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10217800 - 1.0202e+07 =  15800 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10217800 - 1.0202e+07 =  15800 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207383 - 1.0202e+07 =  5383 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10207383 - 1.0202e+07 =  5383 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10270767 - 1.0202e+07 =  68767 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10270767 - 1.0202e+07 =  68767 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10218718 - 1.0202e+07 =  16718 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10218718 - 1.0202e+07 =  16718 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10269514 - 1.0202e+07 =  67514 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10269514 - 1.0202e+07 =  67514 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10225776 - 1.0202e+07 =  23776 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10225776 - 1.0202e+07 =  23776 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10269640 - 1.0202e+07 =  67640 (TTFB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] 10269640 - 1.0202e+07 =  67640 (TTLB)
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] total_ttfb: 2060300
++43200.000000000s -1 BNS:collectPropagationData(): [INFO ] total_ttlb: 2060300
++43200.000000000s -1 BNS:collectPropagationData(): [DEBUG] TTFBs size: 92
++43200.000000000s -1 BNS:collectPropagationData(): [DEBUG] TTLBs size: 92
++43200.000000000s -1 BNS:collectPropagationData(): [DEBUG] Avg. TTFB: 22394
++43200.000000000s -1 BNS:collectPropagationData(): [DEBUG] Avg. TTLB: 22394
++43200.000000000s -1 BNS:collectPropagationData(): [DEBUG] Median TTFB: 8537.5
++43200.000000000s -1 BNS:collectPropagationData(): [DEBUG] Median TTLB: 8537.5
++43200.000000000s -1 BNS:collectPropagationData(): [DEBUG] Coverage: 0.92
++43200.000000000s -1 BNS:collectTrafficData(): [INFO ] Total number of mined blocks: 1, top block Height: 1
++43200.000000000s -1 BNS:collectTrafficData(): [INFO ] Stale rate: 0, totalTraffic: 1.67503e+08, overheadRatio: 0.5232
+BNS:main(): [INFO ] Simulation finished!

--- a/bns/mincast-node.cc
+++ b/bns/mincast-node.cc
@@ -135,7 +135,7 @@ MincastNode::InitBroadcast (Block& b)
 {
     NS_LOG_FUNCTION(this);
 
-    NS_LOG_FUNCTION("InitBroadcast");
+    NS_LOG_INFO("InitBroadcast");
 
             //NS_LOG_INFO ("Broadcasting BLOCK " << b.blockID << ", prevID: " << b.prevID << ", size: " << b.blockSize << ").");
     for (auto p : m_peers) {


### PR DESCRIPTION
1. Limit the miner to only 1 node with only 1 block mined in the entire run.
2. Stop the miner before the 1st broadcast happens.
3. Make sure that new block will always be mined 10 seconds after the simulation.
4. Include some log.

Will work on more related to 
