### PR TITLE
Jzhu340score111111

### DIFF
--- a/bns/bitcoin-node.cc
+++ b/bns/bitcoin-node.cc
@@ -59,7 +59,9 @@ void BitcoinNode::NotifyNewValidBlock(Block &newBlock)
     }
 
     if (!m_isSelfish && !m_isByzantine)
+    {
         InitBroadcast(newBlock);
+    }
 }
 
 void BitcoinNode::NotifyNewBlock(Block &newBlock, bool mined)

--- a/bns/bitcoin-node.cc
+++ b/bns/bitcoin-node.cc
@@ -42,13 +42,14 @@ void BitcoinNode::NotifyNewValidBlock(Block &newBlock)
         if (nBlocks > 0)
         {
 
-            if (m_nMinedBlocks <= nBlocks) // Always mine one more block to ensure the previous one get broadcasted here
+            if (m_nMinedBlocks < nBlocks) // Always mine one more block to ensure the previous one get broadcasted here
             {
                 m_miner->StartMining();
             }
             else
             {
                 m_miner->StopMining();
+                //m_nMinedBlocks--; // Make sure the previous block has been broadcasted here
             }
         }
         else
@@ -57,15 +58,8 @@ void BitcoinNode::NotifyNewValidBlock(Block &newBlock)
         } 
     }
 
-    if (!m_isSelfish && !m_isByzantine && m_nMinedBlocks <= nBlocks)
-    {
+    if (!m_isSelfish && !m_isByzantine)
         InitBroadcast(newBlock);
-    }
-    else
-    {
-        //m_nMinedBlocks--; // Make sure the previous block has been broadcasted here
-        ns3::Simulator::Stop();
-    }
 }
 
 void BitcoinNode::NotifyNewBlock(Block &newBlock, bool mined)

--- a/bns/bitcoin-node.h
+++ b/bns/bitcoin-node.h
@@ -58,6 +58,7 @@ public:
 
     Blockchain *GetBlockchain();
     bool IsMiner();
+    static uint32_t nBlocks;
 
     void SetByzantine(bool byzantine);
     bool IsByzantine();

--- a/bns/bns.cc
+++ b/bns/bns.cc
@@ -57,6 +57,9 @@ struct bnsParams
     uint16_t kadBeta = 5;
     double kadFecOverhead = 0.25;
 
+    // mincast specific
+    bool mincastUseScores = false;
+
     // star topo specific
     std::string starLeafDataRate = "50Mbps";
     std::string starHubDataRate = "100Gbps";
@@ -111,6 +114,7 @@ int main(int argc, char *argv[])
     cmd.AddValue("kadAlpha", "Kadcast or Mincast: Set the alpha factor determining the number of parallel lookup requests.", params.kadAlpha);
     cmd.AddValue("kadBeta", "Kadcast or Mincast: Set the beta factor determining the number of parallel broadcast operations.", params.kadBeta);
     cmd.AddValue("kadFecOverhead", "Kadcast or Mincast: Set the FEC overhead factor.", params.kadFecOverhead);
+    cmd.AddValue("mincastUseScores", "Mincast: Use scores to determine sending BLOCK or INFORM message, instead of percentages.", params.mincastUseScores);
 
     cmd.AddValue("starLeafDataRate", "Set the data rate for each link", params.starLeafDataRate);
     cmd.AddValue("starHubRate", "Set the data rate for the star network hub", params.starHubDataRate);
@@ -141,6 +145,7 @@ int main(int argc, char *argv[])
     bns::MincastNode::kadAlpha = params.kadAlpha;
     bns::MincastNode::kadBeta = params.kadBeta;
     bns::MincastNode::kadFecOverhead = params.kadFecOverhead;
+    bns::MincastNode::mincastUseScores = params.mincastUseScores;
 
     ns3::RngSeedManager::SetSeed(time(0));
 

--- a/bns/bns.cc
+++ b/bns/bns.cc
@@ -38,10 +38,12 @@ double median(std::vector<double> scores);
 struct bnsParams
 {
     uint32_t seed = 23;
-    uint16_t nMinutes = 15;
+    uint16_t nMinutes = 1000;
     uint32_t nPeers = 100;
-    uint32_t nMiners = bns::btcNumPools;
+    //uint32_t nMiners = bns::btcNumPools;
+    uint32_t nMiners = 1;
     uint32_t nBootstrap = nPeers;
+    uint32_t nBlocks = 0;
     double blockSizeFactor = 1.0;
     double blockIntervalFactor = 1.0;
     double byzantineFactor = 0.0;
@@ -102,6 +104,7 @@ int main(int argc, char *argv[])
     cmd.AddValue("nPeers", "Number of peers to build", params.nPeers);
     cmd.AddValue("nBootstrap", "Number of bootstrap peers", params.nBootstrap);
     cmd.AddValue("nMiners", "Number of miners", params.nMiners);
+    cmd.AddValue("nBlocks", "Number of blocks to mine, need nMiners=1, stop when reached, use 0 when infinite", params.nBlocks);
     cmd.AddValue("blockSizeFactor", "Set how big blocks are (as a factor of 1 MB)", params.blockSizeFactor);
     cmd.AddValue("blockIntervalFactor", "Set how fast blocks are produced are (as a factor of 10 minutes)", params.blockIntervalFactor);
     cmd.AddValue("byzantineFactor", "Set what part of nodes are byzantine", params.byzantineFactor);
@@ -129,6 +132,8 @@ int main(int argc, char *argv[])
 
     bns::BitcoinMiner::blockSizeFactor = params.blockSizeFactor;
     bns::BitcoinMiner::blockIntervalFactor = params.blockIntervalFactor;
+
+    bns::BitcoinNode::nBlocks = params.nBlocks;
 
     if (params.unsolicited)
     {

--- a/bns/bns.cc
+++ b/bns/bns.cc
@@ -104,7 +104,7 @@ int main(int argc, char *argv[])
     cmd.AddValue("nPeers", "Number of peers to build", params.nPeers);
     cmd.AddValue("nBootstrap", "Number of bootstrap peers", params.nBootstrap);
     cmd.AddValue("nMiners", "Number of miners", params.nMiners);
-    cmd.AddValue("nBlocks", "Number of blocks to mine, need nMiners=1, stop when reached, use 0 when infinite", params.nBlocks);
+    cmd.AddValue("nBlocks", "Number of blocks to mine, need nMiners=1 and proper nMinutes, stop mining when reached, use 0 when infinite", params.nBlocks);
     cmd.AddValue("blockSizeFactor", "Set how big blocks are (as a factor of 1 MB)", params.blockSizeFactor);
     cmd.AddValue("blockIntervalFactor", "Set how fast blocks are produced are (as a factor of 10 minutes)", params.blockIntervalFactor);
     cmd.AddValue("byzantineFactor", "Set what part of nodes are byzantine", params.byzantineFactor);

--- a/bns/mincast-node.cc
+++ b/bns/mincast-node.cc
@@ -271,7 +271,6 @@ void MincastNode::InitBroadcast(Block &b)
 
     m_doneBlocks[b.blockID] = true;
 
-    NS_LOG_INFO("InitBroadcast!!!NOW!!!");
     //NS_LOG_INFO ("Initializing Broadcast " << b.blockID);
     if (m_maxSeenHeight.find(b.blockID) == std::end(m_maxSeenHeight))
     {

--- a/bns/mincast-node.cc
+++ b/bns/mincast-node.cc
@@ -373,7 +373,7 @@ void MincastNode::BroadcastBlock(Block &b)
 
 void MincastNode::SendBlock(ns3::Ipv4Address &outgoingAddress, Block &b, uint16_t height)
 {
-    NS_LOG_INFO("Sending block: " << b.blockID << " to: " << outgoingAddress);
+    NS_LOG_INFO("Sending BLOCK: " << b.blockID << " to: " << outgoingAddress);
     std::map<uint16_t, MinChunk> chunkMap = Chunkify(b);
 
     std::vector<uint16_t> chunksToSend;

--- a/bns/mincast-node.cc
+++ b/bns/mincast-node.cc
@@ -267,6 +267,7 @@ void MincastNode::InitBroadcast(Block &b)
 
     m_doneBlocks[b.blockID] = true;
 
+    NS_LOG_INFO("InitBroadcast");
     //NS_LOG_INFO ("Initializing Broadcast " << b.blockID);
     if (m_maxSeenHeight.find(b.blockID) == std::end(m_maxSeenHeight))
     {
@@ -319,6 +320,8 @@ void MincastNode::BroadcastBlock(Block &b)
         // NS_LOG_INFO("will broadcast to " << nodeAddresses.size() << " nodes");
 
         int nodeAddrLimit = nodeAddresses.size() == kadBeta ? nodeAddresses.size() - 2 : nodeAddresses.size() - 1, ct = 0;
+        NS_LOG_INFO(kadBeta << " " << ct << " " << nodeAddresses.size());
+
         for (auto nAddr : nodeAddresses)
         {
             if (ct <= nodeAddrLimit)
@@ -942,6 +945,7 @@ void MincastNode::SendRequestMessage(ns3::Ipv4Address &outgoingAddress, uint64_t
     ns3::Ptr<ns3::Packet> packet = ns3::Create<ns3::Packet>();
 
     uint64_t eSenderID = EncodeID(m_nodeID);
+    NS_LOG_INFO("Send REQUEST to node " << eSenderID << " / " << outgoingAddress);
 
     MincastReqHeader rh;
     rh.SetSenderId(eSenderID);
@@ -966,6 +970,7 @@ void MincastNode::SendInformMessage(ns3::Ipv4Address &outgoingAddress, uint64_t 
     ns3::Ptr<ns3::Packet> packet = ns3::Create<ns3::Packet>();
 
     uint64_t eSenderID = EncodeID(m_nodeID);
+    NS_LOG_INFO("Send INFORM to node " << eSenderID << " / " << outgoingAddress);
 
     MincastReqHeader rh;
     rh.SetSenderId(eSenderID);
@@ -1106,7 +1111,7 @@ void MincastNode::RequestInformedBlock(ns3::Ipv4Address &senderAddr, uint64_t bl
     }
     ns3::Simulator::Schedule(nextRequestTime, &MincastNode::RequestInformedBlock, this, senderAddr, blockID);
 
-    NS_LOG_INFO("Requesting informed block " << blockID << " from " << senderAddr);
+    NS_LOG_INFO("Requesting INFORMed block " << blockID << " from " << senderAddr);
 }
 
 void MincastNode::RequestMissingBlock(ns3::Ipv4Address &senderAddr, uint64_t blockID)

--- a/bns/mincast-node.cc
+++ b/bns/mincast-node.cc
@@ -371,7 +371,7 @@ void MincastNode::BroadcastBlock(Block &b)
 
 void MincastNode::SendBlock(ns3::Ipv4Address &outgoingAddress, Block &b, uint16_t height)
 {
-    NS_LOG_INFO("Sending BLOCK: " << b.blockID << " to: " << outgoingAddress);
+    //NS_LOG_INFO("Sending BLOCK: " << b.blockID << " to: " << outgoingAddress);
     std::map<uint16_t, MinChunk> chunkMap = Chunkify(b);
 
     std::vector<uint16_t> chunksToSend;
@@ -979,7 +979,7 @@ void MincastNode::SendRequestMessage(ns3::Ipv4Address &outgoingAddress, uint64_t
     ns3::Ptr<ns3::Packet> packet = ns3::Create<ns3::Packet>();
 
     uint64_t eSenderID = EncodeID(m_nodeID);
-    NS_LOG_INFO("Send REQUEST to node " << eSenderID << " / " << outgoingAddress);
+    //NS_LOG_INFO("Send REQUEST to node " << eSenderID << " / " << outgoingAddress);
 
     MincastReqHeader rh;
     rh.SetSenderId(eSenderID);
@@ -1004,7 +1004,7 @@ void MincastNode::SendInformMessage(ns3::Ipv4Address &outgoingAddress, uint64_t 
     ns3::Ptr<ns3::Packet> packet = ns3::Create<ns3::Packet>();
 
     uint64_t eSenderID = EncodeID(m_nodeID);
-    NS_LOG_INFO("Send INFORM to node " << eSenderID << " / " << outgoingAddress);
+    //NS_LOG_INFO("Send INFORM to node " << eSenderID << " / " << outgoingAddress);
 
     MincastReqHeader rh;
     rh.SetSenderId(eSenderID);

--- a/bns/mincast-node.cc
+++ b/bns/mincast-node.cc
@@ -1147,7 +1147,7 @@ void MincastNode::RequestInformedBlock(ns3::Ipv4Address &senderAddr, uint64_t bl
     }
     ns3::Simulator::Schedule(nextRequestTime, &MincastNode::RequestInformedBlock, this, senderAddr, blockID);
 
-    NS_LOG_INFO("REQUESTing INFORMed block " << blockID << " from " << senderAddr);
+    NS_LOG_INFO("Requesting informed block " << blockID << " from " << senderAddr << " Next: +" << nextRequestTime << "s");
 }
 
 void MincastNode::RequestMissingBlock(ns3::Ipv4Address &senderAddr, uint64_t blockID)

--- a/bns/mincast-node.cc
+++ b/bns/mincast-node.cc
@@ -32,6 +32,8 @@ uint16_t MincastNode::kadBeta = 3;
 
 double MincastNode::kadFecOverhead = 0.25;
 
+bool MincastNode::mincastUseScores = false;
+
 MincastNode::MincastNode(ns3::Ipv4Address address, bool isMiner, double hashRate) : BitcoinNode(address, isMiner, hashRate), m_sending(false)
 {
     NS_LOG_FUNCTION(this);
@@ -57,7 +59,7 @@ void MincastNode::DoDispose(void)
 // Application Methods
 void MincastNode::StartApplication() // Called at time specified by Start
 {
-    NS_LOG_INFO("Starting node " << GetNode()->GetId() << ": " << m_address << " / " << EncodeID(m_nodeID));
+    NS_LOG_INFO("Starting node " << GetNode()->GetId() << ": " << m_address << " / " << EncodeID(m_nodeID) << " / mincastUseScores: " << std::boolalpha << mincastUseScores);
     m_isRunning = true;
     if (!m_socket)
     {
@@ -320,7 +322,6 @@ void MincastNode::BroadcastBlock(Block &b)
         // NS_LOG_INFO("will broadcast to " << nodeAddresses.size() << " nodes");
 
         int nodeAddrLimit = nodeAddresses.size() == kadBeta ? nodeAddresses.size() - 2 : nodeAddresses.size() - 1, ct = 0;
-        NS_LOG_INFO(kadBeta << " " << ct << " " << nodeAddresses.size());
 
         for (auto nAddr : nodeAddresses)
         {
@@ -1111,7 +1112,7 @@ void MincastNode::RequestInformedBlock(ns3::Ipv4Address &senderAddr, uint64_t bl
     }
     ns3::Simulator::Schedule(nextRequestTime, &MincastNode::RequestInformedBlock, this, senderAddr, blockID);
 
-    NS_LOG_INFO("Requesting INFORMed block " << blockID << " from " << senderAddr);
+    NS_LOG_INFO("REQUESTing INFORMed block " << blockID << " from " << senderAddr);
 }
 
 void MincastNode::RequestMissingBlock(ns3::Ipv4Address &senderAddr, uint64_t blockID)

--- a/bns/mincast-node.cc
+++ b/bns/mincast-node.cc
@@ -271,7 +271,7 @@ void MincastNode::InitBroadcast(Block &b)
 
     m_doneBlocks[b.blockID] = true;
 
-    NS_LOG_INFO("InitBroadcast! NOW!!");
+    NS_LOG_INFO("InitBroadcast!!!NOW!!!");
     //NS_LOG_INFO ("Initializing Broadcast " << b.blockID);
     if (m_maxSeenHeight.find(b.blockID) == std::end(m_maxSeenHeight))
     {

--- a/bns/mincast-node.cc
+++ b/bns/mincast-node.cc
@@ -326,11 +326,9 @@ void MincastNode::BroadcastBlock(Block &b)
 
         if (mincastUseScores)
         {
-            NS_LOG_INFO("Use Scores System");
-            NS_LOG_INFO(m_address);
+            //NS_LOG_INFO("Use Scores System");
+            //NS_LOG_INFO(m_address);
 
-
-            //NS_LOG_INFO("numbers: " << subnetLatency);
 
             for (auto nAddr : nodeAddresses)
             {
@@ -350,8 +348,8 @@ void MincastNode::BroadcastBlock(Block &b)
         }
         else
         {
-            NS_LOG_INFO("Use Percentage System");
-            NS_LOG_INFO(m_address);
+            //NS_LOG_INFO("Use Percentage System");
+            //NS_LOG_INFO(m_address);
 
 
             int nodeAddrLimit = nodeAddresses.size() == kadBeta ? nodeAddresses.size() - 2 : nodeAddresses.size() - 1, ct = 0;
@@ -572,7 +570,7 @@ void MincastNode::HandleRead(ns3::Ptr<ns3::Socket> socket)
             uint64_t eSenderID = rh.GetSenderId();
             nodeid_t senderID = DecodeID(eSenderID);
 
-            NS_LOG_INFO("Got REQUEST from node: " << eSenderID << " / " << senderAddr);
+            //NS_LOG_INFO("Got REQUEST from node: " << eSenderID << " / " << senderAddr);
 
             uint64_t blockID = rh.GetBlockId();
 
@@ -587,7 +585,7 @@ void MincastNode::HandleRead(ns3::Ptr<ns3::Socket> socket)
             uint64_t eSenderID = rh.GetSenderId();
             nodeid_t senderID = DecodeID(eSenderID);
 
-            NS_LOG_INFO("Got INFORM from node: " << eSenderID << " / " << senderAddr);
+            //NS_LOG_INFO("Got INFORM from node: " << eSenderID << " / " << senderAddr);
 
             uint64_t blockID = rh.GetBlockId();
 

--- a/bns/mincast-node.h
+++ b/bns/mincast-node.h
@@ -67,6 +67,7 @@ public:
     static uint16_t kadAlpha;
     static uint16_t kadBeta;
     static double kadFecOverhead;
+    static bool mincastUseScores;
 
 protected:
     virtual void DoDispose(void); // inherited from Application base class.

--- a/bns/mincast-node.h
+++ b/bns/mincast-node.h
@@ -305,6 +305,7 @@ protected:
     std::set<uint16_t> m_activeBuckets;
 
     bool m_sending;
+    int mincastScores = 0;
     ns3::EventId m_nextSend;
 };
 


### PR DESCRIPTION
1. Set nMiners=1 as default in the codes.
2. Set nMinutes=1000 as default in the codes
3. Add nBlocks for number of blocks to mine, and only works properly if nMiners=1.
    This is default to 0 as infinite, until user manually set it to positive numbers.
    You need to manually set a proper nMinutes for all the broadcast to process here.
4. Adding the scores system which use subnet latency as parameters.
    We consider the two nodes have much lower latency if they locate within the same subnet, and vise versa.
5. Add mincastUseScores=true to use scores above instead of the percentage system.
6. This change will likely have issues with vis.py @AkshatShetty101 @Adhrit-Shetty please tweak the vis.py or advice proper changes on my logging outputs.

Thanks.

Sample Run:
1. 60 min:
./waf --run "bns --net=kadcast --nPeers=500 --nMinutes=60 --kadBeta=5 --mincastUseScores=true"

2. 6 blocks in total running 100 minutes:
./waf --run "bns --net=kadcast --nPeers=500 --nMinutes=100 --kadBeta=5 --mincastUseScores=true --nBlocks=6 --nMiners=1"